### PR TITLE
Js meridian changes

### DIFF
--- a/source/i18n.js
+++ b/source/i18n.js
@@ -191,6 +191,7 @@ I18n.strftime = function(date, format) {
   if (!options) {
     return date.toString();
   }
+  options.meridian = options.meridian || ["AM", "PM"];
 
   var weekDay = date.getDay();
   var day = date.getDate();
@@ -198,7 +199,7 @@ I18n.strftime = function(date, format) {
   var month = date.getMonth() + 1;
   var hour = date.getHours();
   var hour12 = hour;
-  var meridian = hour > 12? "PM" : "AM";
+  var meridian = hour > 11 ? 1 : 0;
   var secs = date.getSeconds();
   var mins = date.getMinutes();
   var offset = date.getTimezoneOffset();
@@ -208,6 +209,9 @@ I18n.strftime = function(date, format) {
 
   if (hour12 > 12) {
     hour12 = hour12 - 12;
+  }
+  else if (hour12 === 0) {
+    hour12 = 12;
   }
 
   var padding = function(n) {
@@ -230,7 +234,7 @@ I18n.strftime = function(date, format) {
   f = f.replace("%-m", month);
   f = f.replace("%M", padding(mins));
   f = f.replace("%-M", mins);
-  f = f.replace("%p", meridian);
+  f = f.replace("%p", options.meridian[meridian]);
   f = f.replace("%S", padding(secs));
   f = f.replace("%-S", secs);
   f = f.replace("%w", weekDay);

--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -76,6 +76,21 @@ describe("I18n.js", function(){
           am: "AM",
           pm: "PM"
         }
+      },
+
+      "en-US": {
+        date: {
+          formats: {
+            "default": "%d/%m/%Y",
+            "short": "%d de %B",
+            "long": "%d de %B de %Y"
+          },
+            day_names: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+            abbr_day_names: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+            month_names: [null, "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+            abbr_month_names: [null, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"],
+            meridian: ["am", "pm"]
+        }
       }
     };
   });
@@ -505,6 +520,33 @@ describe("I18n.js", function(){
     expect(I18n.strftime(date, "%z")).toBeEqualTo("+0545");
   });
   
+  specify("date formatting with custom meridian", function(){
+    I18n.locale = "en-US";
+    var date = new Date(2009, 3, 26, 19, 35, 44);
+    expect(I18n.strftime(date, "%p")).toBeEqualTo("pm");
+  });
+
+  specify("date formatting meridian boundaries", function(){
+    I18n.locale = "en-US";
+    var date = new Date(2009, 3, 26, 0, 35, 44);
+    expect(I18n.strftime(date, "%p")).toBeEqualTo("am");
+
+    date = new Date(2009, 3, 26, 12, 35, 44);
+    expect(I18n.strftime(date, "%p")).toBeEqualTo("pm");
+  });
+
+  specify("date formatting hour12 values", function(){
+    I18n.locale = "pt-BR";
+    var date = new Date(2009, 3, 26, 19, 35, 44);
+    expect(I18n.strftime(date, "%I")).toBeEqualTo("07");
+
+    date = new Date(2009, 3, 26, 12, 35, 44);
+    expect(I18n.strftime(date, "%I")).toBeEqualTo("12");
+
+    date = new Date(2009, 3, 26, 0, 35, 44);
+    expect(I18n.strftime(date, "%I")).toBeEqualTo("12");
+  });
+
   specify("localize date strings", function(){
     I18n.locale = "pt-BR";
   


### PR DESCRIPTION
This pull request addresses two issues I found with the JS library, and one additional feature.

Issue: 12 noon was calculated as AM.
Issue: 00:00 was being represented as "00" in hour12, when it should be represented as "12" for the purposes of hour12 (as it is 12:00 AM)
Feature: ability to specify meridian strings as part of an i18n config, rather than always using "AM" and "PM".

JS specs are included for all changes, all of which pass for me.
