### PR TITLE
Allow empty strings in pluralization

### DIFF
--- a/source/i18n.js
+++ b/source/i18n.js
@@ -375,13 +375,16 @@ I18n.pluralize = function(count, scope, options) {
 
   switch(Math.abs(count)) {
     case 0:
-      message = translation.zero || translation.none || translation.other || this.missingTranslation(scope, "zero");
+      message = this.isValidNode(translation, "zero") ? translation.zero :
+                this.isValidNode(translation, "none") ? translation.none :
+                this.isValidNode(translation, "other") ? translation.other :
+                this.missingTranslation(scope, "zero");
       break;
     case 1:
-      message = translation.one || this.missingTranslation(scope, "one");
+      message = this.isValidNode(translation, "one") ? translation.one : this.missingTranslation(scope, "one");
       break;
     default:
-      message = translation.other || this.missingTranslation(scope, "other");
+      message = this.isValidNode(translation, "other") ? translation.other : this.missingTranslation(scope, "other");
   }
 
   return this.interpolate(message, options);

--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -216,6 +216,12 @@ describe("I18n.js", function(){
     expect(actual).toBeEqualTo("You have no new messages (5 unread)");
   });
   
+  specify("pluralize should allow empty strings", function(){
+    I18n.translations["en"]["inbox"]["zero"] = "";
+
+    expect(I18n.p(0, "inbox")).toBeEqualTo("");
+  });
+
   specify("numbers with default settings", function(){
     expect(I18n.toNumber(1)).toBeEqualTo("1.000");
     expect(I18n.toNumber(12)).toBeEqualTo("12.000");


### PR DESCRIPTION
Use case: Given a number of hours, minutes, and seconds, I want to generate one of the following strings:
"5 hours 3 minutes 20 seconds" OR "3 minutes 20 seconds" OR "20 seconds"
#### Expected Usage

```
// translation data
{ 
    "something_hours" : {
        "zero" : "",
        "one" : "{{count}} hour ",
        "other" : "{{count} hours ",
    },
    "something_minutes" : {
        "zero" : "",
        "one" : "{{count}} minute ",
        "other" : "{{count} minutes ",
    },
    "something_seconds" : {
        "zero" : "",
        "one" : "{{count}} second",
        "other" : "{{count} seconds",
    }
}

// generate the string
var str = I18n.p(myHours, "something_hours");
str += I18n.p(myMinutes, "something_minutes");
str += I18n.p(mySeconds, "something_seconds");
```
#### The Problem

An empty string in JS evaluates to false. This causes tests like `translations.zero || translations.none || ...` to fail.
#### Proposed Solution

Rather than do truthy comparisons to determine if a value should be used, check the validity of the scope endpoint. If it is null or undefined, do not use it (as is done elsewhere). Otherwise, use whatever the user has specified even if it is an empty string.

The attached commits achieve this result.
#### Pitfalls

This does not prevent the implementor from hanging himself, if a different invalid value is put in the i18n file, such as an object, array, or number. However, this is an existing possibility which is not affected by these changes.
