### PR TITLE
Automatically generate I18n js in dev/production

### DIFF
--- a/lib/i18n-js/railtie.rb
+++ b/lib/i18n-js/railtie.rb
@@ -5,9 +5,15 @@ module SimplesIdeias
         load File.dirname(__FILE__) + "/../tasks/i18n-js_tasks.rake"
       end
       
+      # Used for development
       config.to_prepare do
         SimplesIdeias::I18n.export!
       end
+      
+      # Used for production
+      config.after_initialize do
+         SimplesIdeias::I18n.export!
+       end
     end
   end
 end


### PR DESCRIPTION
Use config.to_prepare to automatically export I18n per request in development and once in production
