### PR TITLE
[rails 3.1] create translations.js in vendor/assets/javascripts

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -32,7 +32,11 @@ module SimplesIdeias
           end
         end
       else
-        save translations, "vendor/assets/javascripts/translations.js"
+        if Rails::VERSION::STRING =~ /3\.1/
+          save translations, "vendor/assets/javascripts/translations.js"
+        else
+          save translations, "public/javascripts/translations.js"
+        end
       end
     end
 


### PR DESCRIPTION
this is needed to be able to require translations.js from the main application.js in rails 3.1
