### PR TITLE
Change rake dependency to pessimistic one to avoid ArgumentError: undefined class/module YAML::Syck::DefaultKey

### DIFF
--- a/i18n-js.gemspec
+++ b/i18n-js.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 2.6"
   s.add_development_dependency "ruby-debug19"
   s.add_development_dependency "spec-js", "~> 0.1.0.beta.0"
+  # FIX to avoid undefined class/module YAML::Syck::DefaultKey ArgumentError
   s.add_development_dependency "rake", "~> 0.8.7"
 end


### PR DESCRIPTION
Hi, I am Ruby coder in Tokyo, Japan, trying to install your i18n-js gem.

I am using JRuby 1.6.3, which comes bundled with RubyGems 1.5.1. When I tried to install the i18n-js gem, I got this error: 

C:\skunkworx>jruby -S gem install i18n-js
ERROR:  While executing gem ... (ArgumentError)
    undefined class/module YAML::Syck::DefaultKey

Doing a bit of investigating, I found that if the rake dependency is changed from an absolute to a pessimistic one (spermy), Rubygems is happy and the install completes perfectly fine.

I know that there are many people on JRuby who might need your gem, but cannot install for this error. Could you have a look at this small fix and see if it can help?
