### PR TITLE
One js per locale

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -31,10 +31,10 @@ module SimplesIdeias
     def export!
       if config?
         for options in config[:translations]
-          if options[:file] =~ /%\{locale\}/
+          if options[:file] =~ ::I18n::INTERPOLATION_PATTERN
             ::I18n.available_locales.each do |locale|
               result = scoped_translations("#{locale}.#{options[:only]}")
-              save result, options[:file].gsub(/%\{locale\}/, locale.to_s) unless result.empty?
+              save result, ::I18n.interpolate(options[:file],{:locale => locale}) unless result.empty?
             end
           else
             options.reverse_merge!(:only => "*")

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -93,6 +93,13 @@ describe SimplesIdeias::I18n do
     File.should be_file(Rails.root.join("public/javascripts/tudo.js"))
   end
 
+  it "exports to a JS file per available locale" do
+    set_config "js_file_per_locale.yml"
+    SimplesIdeias::I18n.export!
+    
+    File.should be_file(Rails.root.join("public/javascripts/i18n/en.js"))
+  end
+
   it "exports with multiple conditions" do
     set_config "multiple_conditions.yml"
     SimplesIdeias::I18n.export!

--- a/spec/resources/js_file_per_locale.yml
+++ b/spec/resources/js_file_per_locale.yml
@@ -1,0 +1,3 @@
+translations:
+  - file: "public/javascripts/i18n/%{locale}.js"
+    only: '*'


### PR DESCRIPTION
It is not really a supported feature. The feature is not the possibility of creating a scope but the possibility of generating a language file for every scope. This way you dont have to worry about modifying the yml file if you add support for a new language and not have a very long list of entries in the configuration file.

This is a harmless addition and provides great functionality so I urge you to reconsider. If you are dealing with large amount of strings and a very complicated set of strings for different parts of your frontend it is really a good feature.

Test is provided for the feature, please reconsider. Its critical for our workflow :S
