### PR TITLE
Locale fallback

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -92,6 +92,19 @@ You can set default values for missing scopes:
   // with interpolation
   I18n.t("noun", {defaultValue: "I'm a {{noun}}", noun: "Mac"});
 
+Translation fallback can be handled by taking from I18n.defaultLocale.
+To allow this in your application.html.erb specify:
+
+  <script type="text/javascript">
+    I18n.fallbacks = true;
+  </script>
+
+Then missing translation will be taken from your I18n.defaultLocale.
+Example:
+  // if I18n.defaultLocale = "en" and translation doesn't exist for I18n.locale = "de"
+  I18n.t("some.missing.scope");
+  // this key will be taken from "en" locale scope
+
 Pluralization is possible as well:
 
   I18n.t("inbox.counting", {count: 10}); // You have 10 messages

--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -135,6 +135,17 @@ describe("I18n.js", function(){
     expect(I18n.t("greetings.stranger")).toBeEqualTo("Hello stranger!");
   });
 
+  specify("translation should fall if locale is missing", function(){
+    I18n.locale = "pt-BR";
+    expect(I18n.t("greetings.stranger")).toBeEqualTo("[missing \"pt-BR.greetings.stranger\" translation]");
+  });
+
+  specify("translation should handle fallback if I18n.fallbacks == true", function(){
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    expect(I18n.t("greetings.stranger")).toBeEqualTo("Hello stranger!");
+  });
+
   specify("single interpolation", function(){
     actual = I18n.t("greetings.name", {name: "John Doe"});
     expect(actual).toBeEqualTo("Hello John Doe!");

--- a/vendor/assets/javascripts/i18n.js
+++ b/vendor/assets/javascripts/i18n.js
@@ -4,6 +4,9 @@ var I18n = I18n || {};
 // Set default locale to english
 I18n.defaultLocale = "en";
 
+// Set default handling of translation fallbacks to false
+I18n.fallbacks = false;
+
 // Set default separator
 I18n.defaultSeparator = ".";
 
@@ -20,8 +23,10 @@ I18n.isValidNode = function(obj, node) {
 }
 
 I18n.lookup = function(scope, options) {
+  var options = options || {};
+  var lookupInitialScope = scope;
   var translations = this.prepareOptions(I18n.translations);
-  var messages = translations[I18n.currentLocale()];
+  var messages = translations[options.locale || I18n.currentLocale()];
   options = this.prepareOptions(options);
 
   if (!messages) {
@@ -43,6 +48,9 @@ I18n.lookup = function(scope, options) {
     messages = messages[currentScope];
 
     if (!messages) {
+      if (I18n.fallbacks && !options.fallback) {
+        messages = I18n.lookup(lookupInitialScope, this.prepareOptions({ locale: I18n.defaultLocale, fallback: true }, options));
+      }
       break;
     }
   }


### PR DESCRIPTION
In order to handle I18n-js fallback. 
And prior to issue #35 here is handling of lookup in more simply way. 
Tests and doc changes are also there.
This also adds explicit setting of translation locale. Can be merged with previous pull request.
https://github.com/fnando/i18n-js/pull/61

Would be nice to have locale fallback and locale as parameter in I18n-js.
Thanks. 
