### PR TITLE
If a config file exists but doesn't contain a translations hash then export errors

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -15,7 +15,7 @@ module SimplesIdeias
     # full environment will be available during asset compilation.
     # This is required to ensure I18n is loaded.
     def assert_usable_configuration!
-      @usable_configuration ||= Rails.version >= "3.1.1" && 
+      @usable_configuration ||= Rails.version >= "3.1.1" &&
         Rails.application.config.assets.initialize_on_precompile ||
         raise("Cannot precompile i18n-js translations unless environment is initialized. Please set config.assets.initialize_on_precompile to true.")
     end
@@ -75,7 +75,7 @@ module SimplesIdeias
     end
 
     def translation_segments
-      if config?
+      if config? && config[:translations]
         configured_segments
       else
         {"#{export_dir}/translations.js" => translations}
@@ -170,3 +170,4 @@ module SimplesIdeias
     end
   end
 end
+

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -88,6 +88,12 @@ describe SimplesIdeias::I18n do
     File.should be_file(Rails.root.join("public/javascripts/tudo.js"))
   end
 
+  it "ignores an empty config file" do
+    set_config "no_config.yml"
+    SimplesIdeias::I18n.export!
+    Rails.root.join(SimplesIdeias::I18n.export_dir, "translations.js").should be_file
+  end
+
   it "exports to a JS file per available locale" do
     set_config "js_file_per_locale.yml"
     SimplesIdeias::I18n.export!
@@ -193,3 +199,4 @@ describe SimplesIdeias::I18n do
     SimplesIdeias::I18n.translations
   end
 end
+

--- a/spec/resources/no_config.yml
+++ b/spec/resources/no_config.yml
@@ -1,0 +1,2 @@
+#This file has no config
+


### PR DESCRIPTION
I have added a spec for an empty config file as this was causing an export error.

To replicate the bug, create a config file but leave it empty.

```
gazler@gazler-desktop:~/development/rails/livestax$ rake i18n:js:export --trace
** Invoke i18n:js:export (first_time)                                                                          
** Invoke environment (first_time)
** Execute environment
** Execute i18n:js:export
rake aborted!
You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.each
/home/gazler/.rvm/gems/ruby-1.9.2-p290@rails3_1/gems/i18n-js-2.0.1/lib/i18n-js.rb:34:in `export!'
/home/gazler/.rvm/gems/ruby-1.9.2-p290@rails3_1/gems/i18n-js-2.0.1/lib/i18n-js/rake.rb:9:in `block (2 levels) in <top (required)>'
```
