### PR TITLE
Set i18n-js.asset_dependencies to run before i18n-js.initialize initializer

### DIFF
--- a/lib/i18n-js/engine.rb
+++ b/lib/i18n-js/engine.rb
@@ -3,7 +3,8 @@ module SimplesIdeias
     class Engine < ::Rails::Engine
       I18N_TRANSLATIONS_ASSET = "i18n/translations"
 
-      initializer "i18n-js.asset_dependencies", :after => "sprockets.environment" do
+      initializer "i18n-js.asset_dependencies", :after => "sprockets.environment",
+                                                :before => "i18n-js.initialize" do
         next unless SimplesIdeias::I18n.has_asset_pipeline?
 
         config = I18n.config_file


### PR DESCRIPTION
Hello,

We're having an [issue](https://github.com/resolve/refinerycms/issues/1197) @ Refinery CMS with i18n-js. 

Here's a short version - Refinery CMS [sets one if it's initializer to run after set_routes_reloader_hook](https://github.com/resolve/refinerycms/blob/master/pages/lib/refinery/pages/engine.rb#L40). Because i18n-js gets loaded after Refinery CMS we're experiencing `can't modify immutable index` exception when trying to run `rake assets:precompile`. It's happening because i18n-js initializer order originally is set to run after `sprockets.environment` but because Refinery CMS sets order to run after `set_routes_reloader_hook` i18n-js initializer gets executed after `set_routes_reloader_hook` too.

In this PR I added `:before => "i18n-js.initialize"` so that initializer gets run before `set_routes_reloader_hook`.

I totally understand if you don't want to accept this patch but at this point I don't see a better way to fix our issue. If you have other suggestions please do advise.

Thanks!
