### PR TITLE
Some improvements to language fallback

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -100,18 +100,25 @@ You can set default values for missing scopes:
   // with interpolation
   I18n.t("noun", {defaultValue: "I'm a {{noun}}", noun: "Mac"});
 
-Translation fallback can be handled by taking from I18n.defaultLocale.
-To allow this in your application.html.erb specify:
+Translation fallback can be enabled by adding to your <tt>application.html.erb</tt>:
 
   <script type="text/javascript">
     I18n.fallbacks = true;
   </script>
 
-Then missing translation will be taken from your I18n.defaultLocale.
+By default missing translations will first be looked for in less
+specific versions of the requested locale and if that fails by taking
+them from your I18n.defaultLocale.
 Example:
-  // if I18n.defaultLocale = "en" and translation doesn't exist for I18n.locale = "de"
+  // if I18n.defaultLocale = "en" and translation doesn't exist for I18n.locale = "de-DE"
   I18n.t("some.missing.scope");
-  // this key will be taken from "en" locale scope
+  // this key will be taken from "de" locale scope
+  // or, if that also doesn't exist, from "en" locale scope
+
+Custom fallback rules can also be specified for a particular language,
+for example:
+
+  I18n.fallbackRules.no = [ "nb", "en" ];
 
 Pluralization is possible as well and by default provides english rules:
 

--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -91,6 +91,14 @@ describe("I18n.js", function(){
             abbr_month_names: [null, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"],
             meridian: ["am", "pm"]
         }
+      },
+
+      "de": {
+        hello: "Hallo Welt!"
+      },
+
+      "nb": {
+        hello: "Hei Verden!"
       }
     };
   });
@@ -155,6 +163,19 @@ describe("I18n.js", function(){
     I18n.locale = "fr";
     I18n.fallbacks = true;
     expect(I18n.t("greetings.stranger")).toBeEqualTo("Hello stranger!");
+  });
+
+  specify("translation should handle fallback to less specific locale", function(){
+    I18n.locale = "de-DE";
+    I18n.fallbacks = true;
+    expect(I18n.t("hello")).toBeEqualTo("Hallo Welt!");
+  });
+
+  specify("translation should handle fallback via custom rules", function(){
+    I18n.locale = "no";
+    I18n.fallbacks = true;
+    I18n.fallbackRules.no = [ "nb" ];
+    expect(I18n.t("hello")).toBeEqualTo("Hei Verden!");
   });
 
   specify("single interpolation", function(){


### PR DESCRIPTION
These changes improve support for fallbacks as follows:
- Fallback properly when the request locale does exist at all
- Try more generic locale before the default locale (eg. de-DE -> de -> en)
- Allow custom fallback rules for special cases (eg. no -> nb)

This is all patterned on how I18n::Backend::Fallbacks class works in rails i18n.
