### PR TITLE
If you have a scope like "*.*.*.blah.*", it blows up with a NoMethodError -- this stops that from happening

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -132,7 +132,8 @@ module SimplesIdeias
       result = {}
 
       [scopes].flatten.each do |scope|
-        deep_merge! result, filter(translations, scope)
+        scope_result = filter(translations, scope)
+        deep_merge! result, scope_result if scope_result
       end
 
       result
@@ -150,6 +151,7 @@ module SimplesIdeias
           tmp = scopes.empty? ? translations : filter(translations, scopes)
           results[scope.to_sym] = tmp unless tmp.nil?
         end
+        return nil if results.empty?
         return results
       elsif translations.respond_to?(:has_key?) && translations.has_key?(scope.to_sym)
         return {scope.to_sym => scopes.empty? ? translations[scope.to_sym] : filter(translations[scope.to_sym], scopes)}

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -109,11 +109,11 @@ describe SimplesIdeias::I18n do
   it "multiple wildcards" do
     result = SimplesIdeias::I18n.scoped_translations("*.*.test.*")
 
-    result.should == {:en => {}, :fr => {}}
+    result.should == {}
 
     result = SimplesIdeias::I18n.scoped_translations("*.*.*.test.*")
 
-    result.should == {:en => {:number => {}, :date => {}, :time => {}, :admin => {}}, :fr => {:number => {}, :date => {}, :time => {}, :admin => {}}}
+    result.should == {}
   end
 
   it "filters translations using scope *.date.formats" do


### PR DESCRIPTION
If you load the default Rails locale file with a scope like `*.*.*.blah.*`, you get:

NoMethodError: undefined method `has_key?' for #<Array:0x00000005a59308>
/usr/local/rvm/gems/ruby-1.9.2-p320@silly/gems/i18n-js-2.1.2/lib/i18n-js.rb:155:in`filter'

This commit covers that
