### PR TITLE
Multiple filters

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -51,7 +51,8 @@ module SimplesIdeias
 
     def segments_per_locale(pattern,scope)
       ::I18n.available_locales.each_with_object({}) do |locale,segments|
-        result = scoped_translations("#{locale}.#{scope}")
+        scopes = [scope].flatten.map{ |s| "#{locale}.#{s}"}
+        result = scoped_translations(scopes)
         unless result.empty?
           segment_name = ::I18n.interpolate(pattern,{:locale => locale})
           segments[segment_name] = result
@@ -135,7 +136,6 @@ module SimplesIdeias
       [scopes].flatten.each do |scope|
         deep_merge! result, filter(translations, scope)
       end
-
       result
     end
 
@@ -152,7 +152,7 @@ module SimplesIdeias
           results[scope.to_sym] = tmp unless tmp.nil?
         end
         return results
-      elsif translations.has_key?(scope.to_sym)
+      elsif translations.is_a?(Hash) && translations.has_key?(scope.to_sym)
         return {scope.to_sym => scopes.empty? ? translations[scope.to_sym] : filter(translations[scope.to_sym], scopes)}
       end
       nil
@@ -167,11 +167,11 @@ module SimplesIdeias
     end
 
     def deep_merge(target, hash) # :nodoc:
-      target.merge(hash, &MERGER)
+      target.merge(hash || { }, &MERGER)
     end
 
     def deep_merge!(target, hash) # :nodoc:
-      target.merge!(hash, &MERGER)
+      target.merge!(hash || { }, &MERGER)
     end
   end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -106,6 +106,14 @@ describe SimplesIdeias::I18n do
     File.should be_file(Rails.root.join("public/javascripts/bitsnpieces.js"))
   end
 
+  it "filters translations for exported JS files per locale" do
+    set_config "js_file_per_locale.yml", :only => ["date", "number"]
+
+    result = SimplesIdeias::I18n.export!
+    result[:en].keys.collect(&:to_s).sort.should == %w[ date number ]
+    result[:fr].keys.collect(&:to_s).sort.should == %w[ date number ]
+  end
+
   it "filters translations using scope *.date.formats" do
     result = SimplesIdeias::I18n.filter(translations, "*.date.formats")
     result[:en][:date].keys.should == [:formats]

--- a/spec/resources/locales.yml
+++ b/spec/resources/locales.yml
@@ -1,4 +1,5 @@
 en:
+  "foo baz": "bar"
   number:
     format:
       separator: "."


### PR DESCRIPTION
Check that SimplesIdeias::I18n.export! can filter multiple
translations and export a JS file per locale.
- Add a test for filtering multiple items with a js file for each locale
- Fix having an array for the only attribute
- Fix the case where filter returns nil
- Fix the case where a yaml file has a key that doesn't point to a hash
- Change export! to return a hash of all of the translations that were
  written to disk
- Instead of having to create a new yaml file to get the correct options
  that you are looking for, you can mock out the config options of an
  existing yaml file.
