### PR TITLE
Use standard for loop instead of forEach

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -96,7 +96,8 @@
     // Compute each locale with its country code.
     // So this will return an array containing both
     // `de-DE` and `de` locales.
-    locales.forEach(function(locale){
+    for(var i = 0, length = locales.length; i < length; ++i) {
+      locale = locales[i];
       countryCode = locale.split("-")[0];
 
       if (!~list.indexOf(locale)) {
@@ -106,7 +107,7 @@
       if (I18n.fallbacks && countryCode && countryCode !== locale && !~list.indexOf(countryCode)) {
         list.push(countryCode);
       }
-    });
+    }
 
     // No locales set? English it is.
     if (!locales.length) {


### PR DESCRIPTION
IE8 and other older browsers don't support ECMAScript 5's Array.prototype.forEach. We don't really
need it so it's now replaced with a good old for loop which should work in pretty much every
browser known to mankind.

This fixes issue #97.
