### PR TITLE
added first level null check

### DIFF
--- a/vendor/assets/javascripts/i18n.js
+++ b/vendor/assets/javascripts/i18n.js
@@ -198,7 +198,9 @@ I18n.translate = function(scope, options) {
   var translation = this.lookup(scope, options);
 
   try {
-    if (typeof(translation) == "object") {
+    if (!translation) {
+      return this.missingTranslation(scope);
+    } else if (typeof(translation) == "object") {
       if (typeof(options.count) == "number") {
         return this.pluralize(options.count, scope, options);
       } else {


### PR DESCRIPTION
This fix will help us return translation missing message if first level object is null 
