### PR TITLE
fixing a small typo in the js specs. fall -> fail

### DIFF
--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -148,7 +148,7 @@ describe("I18n.js", function(){
     expect(I18n.t("hello", {locale: "pt-BR"})).toBeEqualTo("Olá Mundo!");
   });
 
-  specify("translation should fall if locale is missing", function(){
+  specify("translation should fail if locale is missing", function(){
     I18n.locale = "pt-BR";
     expect(I18n.t("greetings.stranger")).toBeEqualTo("[missing \"pt-BR.greetings.stranger\" translation]");
   });


### PR DESCRIPTION
translations should _fail_ if locale is missing
