### PR TITLE
Make the cache file world writeable on first write.

### DIFF
--- a/lib/i18n-js/engine.rb
+++ b/lib/i18n-js/engine.rb
@@ -49,10 +49,12 @@ module SimplesIdeias
 
       def self.write_hash!
         FileUtils.mkdir_p Rails.root.join("tmp")
+        already_exists = File.exists?(load_path_hash_cache)
 
         File.open(load_path_hash_cache, "w+") do |f|
           f.write(cached_load_path_hash)
         end
+        File.chmod(0666, load_path_hash_cache) unless already_exists
       end
 
       class << self


### PR DESCRIPTION
This addresses an issue where the user that first wrote to this
file (during setup, perhaps) is not the same user that the
application later runs as.

The mode is only set during the first write.
