### PR TITLE
Revise and rename version number components

### DIFF
--- a/lib/i18n/js/version.rb
+++ b/lib/i18n/js/version.rb
@@ -3,8 +3,10 @@ module I18n
     module Version
       MAJOR = 3
       MINOR = 0
-      PATCH = 0
-      STRING = "#{MAJOR}.#{MINOR}.#{PATCH}.rc3"
+      TINY  = 0
+      PATCH = "rc3" # Could be nil
+      
+      STRING = [MAJOR, MINOR, TINY, PATCH].compact.join('.')
     end
   end
 end


### PR DESCRIPTION
Since a gem could be released as beta and RC versions
It is more sensible to add an extra component storing "beta3" or "rc2" instead of adding it in the string
