### PR TITLE
Per locale multiple onlys

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -53,7 +53,7 @@ module SimplesIdeias
         segment_name = ::I18n.interpolate(pattern,{:locale => locale})
         [scopes].flatten.each do |scope|
           result = scoped_translations("#{locale}.#{scope}")
-          (segments[segment_name] ||= {}).update(result) unless result.empty?
+          (segments[segment_name] ||= {}).deep_merge!(result) unless result.empty?
         end
       end
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -106,6 +106,16 @@ describe SimplesIdeias::I18n do
     File.should be_file(Rails.root.join("public/javascripts/bitsnpieces.js"))
   end
 
+  it "exports with multiple conditions and a JS file per locale" do
+    set_config "js_file_per_locale_with_multiple_conditions.yml"
+    SimplesIdeias::I18n.export!
+    filename = Rails.root.join("public/javascripts/i18n/multi-condition-multi-locale/en.js")
+    File.should be_file(filename)
+    file = File.read(filename)
+    file.should =~ /"formats"/
+    file.should =~ /"currency"/
+  end
+
   it "filters translations using scope *.date.formats" do
     result = SimplesIdeias::I18n.filter(translations, "*.date.formats")
     result[:en][:date].keys.should == [:formats]


### PR DESCRIPTION
This didn't used to work:

``` YAML
translations:
  - file: "public/javascripts/i18n/multi-condition-multi-locale/%{locale}.js"
    only:
      - "date.formats"
      - "number.currency"
```

Now it does.
