### PR TITLE
fix 'invalid byte sequence in US-ASCII' in i18n/translations.js.erb

### DIFF
--- a/app/assets/javascripts/i18n/translations.js.erb
+++ b/app/assets/javascripts/i18n/translations.js.erb
@@ -1,4 +1,4 @@
-<%# encoding: utf-8%>
+/* coding: UTF-8 */
 //= require i18n
 //= require_self
 ;I18n.translations = <%= I18n::JS.filtered_translations.to_json %>;


### PR DESCRIPTION
It's basically the same as in this pull request: https://github.com/fnando/i18n-js/pull/74

Not sure if there is a better way in Rails3 now. However, this fixes the problem.
