### PR TITLE
set UTF-8 encoding to translations.js.erb

### DIFF
--- a/app/assets/javascripts/i18n/translations.js.erb
+++ b/app/assets/javascripts/i18n/translations.js.erb
@@ -1,3 +1,5 @@
+<%# encoding: utf-8 %>
+
 //= require i18n/shims
 //= require i18n
 //= require_self


### PR DESCRIPTION
This fixes issue #137. 

The file translations.js.erb should be forced to use UTF-8 or there will be an 'invalid byte sequence'-error in Rails 3.2.13 when non us-ascii characters are used in some translation files.
