### PR TITLE
Move translations into a seperate file to allow encoding specification.

### DIFF
--- a/app/assets/javascripts/i18n/filtered_translations.js.erb
+++ b/app/assets/javascripts/i18n/filtered_translations.js.erb
@@ -1,0 +1,2 @@
+<%# encoding: utf-8 %>
+;I18n.translations = <%= I18n::JS.filtered_translations.to_json %>;

--- a/app/assets/javascripts/i18n/translations.js.erb
+++ b/app/assets/javascripts/i18n/translations.js.erb
@@ -1,4 +1,3 @@
 //= require i18n/shims
 //= require i18n
-//= require_self
-;I18n.translations = <%= I18n::JS.filtered_translations.to_json %>;
+//= require i18n/filtered_translations


### PR DESCRIPTION
Specifying the encoding within translations.js breaks manifest requires.

Added as #137 didn't fix things for me.
