### PR TITLE
removed git shellouts from gemspec

### DIFF
--- a/i18n-js.gemspec
+++ b/i18n-js.gemspec
@@ -12,9 +12,8 @@ Gem::Specification.new do |s|
   s.summary     = "It's a small library to provide the Rails I18n translations on the Javascript."
   s.description = s.summary
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir["{lib,vendor,config}/**/*"] + ["README.rdoc", "Rakefile"]
+  s.test_files    = Dir["spec/**/*"]
   s.require_paths = ["lib"]
 
   s.add_dependency "i18n"


### PR DESCRIPTION
Using git inside a gemspec is kindof problematic and not recommended as a general case.

This patch replaces the shellouts by calls to ruby's `Dir`. It also removes the `executables` directive, since this gem has none.
