### PR TITLE
In rails4 the asset pipeline is enabled by default

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -21,7 +21,7 @@ module SimplesIdeias
     end
 
     def has_asset_pipeline?
-      Rails.configuration.respond_to?(:assets) && Rails.configuration.assets.enabled
+      Rails.configuration.respond_to?(:assets)
     end
 
     def config_file


### PR DESCRIPTION
Hi

I created a rails4 branch where the config.assets.enabled = true shouldnt be defined in order for the i18n-js to work properly.
In rails4 the config.assets.enabled = true is never defined because in the assets are always enabled if the sprockets is tied.
