### PR TITLE
Add support for +00:00 style time zone designator

### DIFF
--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -445,6 +445,10 @@ describe("I18n.js", function(){
     actual = I18n.parseDate("2011-07-20T12:51:55+0000");
     expect(actual.toString()).toBeEqualTo(expected.toString());
 
+    expected = new Date(Date.UTC(2011, 6, 20, 12, 51, 55));
+    actual = I18n.parseDate("2011-07-20T12:51:55+00:00");
+    expect(actual.toString()).toBeEqualTo(expected.toString());
+
     expected = new Date(Date.UTC(2011, 6, 20, 13, 03, 39));
     actual = I18n.parseDate("Wed Jul 20 13:03:39 +0000 2011");
     expect(actual.toString()).toBeEqualTo(expected.toString());

--- a/vendor/assets/javascripts/i18n.js
+++ b/vendor/assets/javascripts/i18n.js
@@ -244,8 +244,9 @@ I18n.parseDate = function(date) {
   //   yyyy-mm-dd[ T]hh:mm::ss
   //   yyyy-mm-dd[ T]hh:mm::ssZ
   //   yyyy-mm-dd[ T]hh:mm::ss+0000
+  //   yyyy-mm-dd[ T]hh:mm::ss+00:00
   //
-  matches = date.toString().match(/(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2}))?(Z|\+0000)?/);
+  matches = date.toString().match(/(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2}))?(Z|\+00:?00)?/);
 
   if (matches) {
     for (var i = 1; i <= 6; i++) {


### PR DESCRIPTION
The ISO8601 standard allows for a colon separator in time zone designators, which i18n-js is currently unable to parse correctly.
