### PR TITLE
Move missing placeholder text generation into its own function

### DIFF
--- a/vendor/assets/javascripts/i18n.js
+++ b/vendor/assets/javascripts/i18n.js
@@ -183,7 +183,7 @@ I18n.interpolate = function(message, options) {
     value = options[name];
 
     if (!this.isValidNode(options, name)) {
-      value = this.missingPlaceholder(placeholder);
+      value = this.missingPlaceholder(placeholder, message);
     }
 
     regex = new RegExp(placeholder.replace(/\{/gm, "\\{").replace(/\}/gm, "\\}"));
@@ -521,7 +521,7 @@ I18n.missingTranslation = function() {
   return message;
 };
 
-I18n.missingPlaceholder = function(placeholder) {
+I18n.missingPlaceholder = function(placeholder, message) {
   return "[missing " + placeholder + " value]";
 };
 


### PR DESCRIPTION
Currently missing translations are handled using I18n.missingTranslation, which allows overriding the default handling (for example to report missing translations).

This pull request changes missing placeholder text generation to I18n.missingPlaceholder, so the default functionality can be overridden for it as well.
