### PR TITLE
Rails 4: Fixed 'Uncaught SyntaxError: Unexpected token ILLEGAL'

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -123,7 +123,7 @@ module SimplesIdeias
       File.open(file, "w+") do |f|
         f << %(var I18n = I18n || {};\n)
         f << %(I18n.translations = );
-        f << translations.to_json
+        f << JSON.generate(translations, ascii_only: true)
         f << %(;)
       end
     end

--- a/vendor/assets/javascripts/i18n/translations.js.erb
+++ b/vendor/assets/javascripts/i18n/translations.js.erb
@@ -3,7 +3,7 @@
 <% SimplesIdeias::I18n.assert_usable_configuration! %>
 var I18n = I18n || {};
 I18n.translations = <%=
-  SimplesIdeias::I18n.translation_segments.each_with_object({}) do |(name, segment),translations|
+  JSON.generate(SimplesIdeias::I18n.translation_segments.each_with_object({}) do |(name, segment),translations|
     translations.merge!(segment)
-  end.to_json
+  end, ascii_only: true)
 %>;


### PR DESCRIPTION
Change related to the way Rails 4 encodes JSON. Long story short: now Rails doesn't escape unicode entities.
http://omegadelta.net/2013/04/28/changes-to-how-rails-3-2-13-and-4-0-encodes-unicode-in-json/
