### PR TITLE
UTF-8 fix

### DIFF
--- a/vendor/assets/javascripts/i18n/translations.js.erb
+++ b/vendor/assets/javascripts/i18n/translations.js.erb
@@ -1,3 +1,5 @@
+<%# encoding: utf-8%>
+
 <% SimplesIdeias::I18n.assert_usable_configuration! %>
 var I18n = I18n || {};
 I18n.translations = <%=


### PR DESCRIPTION
When I18n yml files contain UTF-8 characters (as ë or é), rendering the `vendor/assets/javascripts/i18n/translations.js.erb` template fails. This is fixed by adding an encoding header to the template.
