### PR TITLE
Ensure cache path exists

### DIFF
--- a/lib/i18n-js/middleware.rb
+++ b/lib/i18n-js/middleware.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module SimplesIdeias
   module I18n
     class Middleware
@@ -47,6 +49,7 @@ module SimplesIdeias
         end
 
         unless valid_cache.all?
+          FileUtils.mkdir_p cache_path.dirname
           File.open(cache_path, "w+") do |file|
             file << new_cache.to_yaml
           end


### PR DESCRIPTION
In some Rails projects the tmp and/or cache dir is not committed to the git repository. In these cases starting the application fails with the error: 

```
Error: Errno::ENOENT: No such file or directory - /path/to/repository/tmp/cache/i18n-js.yml
```

This is fixed by making sure the `cache_path.dirname` exists before attempting to create the cache file.
