### PR TITLE
Support multiple conditions together with a JS file per locale.

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -50,7 +50,8 @@ module SimplesIdeias
 
     def segments_per_locale(pattern,scope)
       ::I18n.available_locales.each_with_object({}) do |locale,segments|
-        result = scoped_translations("#{locale}.#{scope}")
+        scope = [scope] unless scope.respond_to?(:each)
+        result = scoped_translations(scope.collect{|s| "#{locale}.#{s}"})
         unless result.empty?
           segment_name = ::I18n.interpolate(pattern,{:locale => locale})
           segments[segment_name] = result

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -117,6 +117,18 @@ describe SimplesIdeias::I18n do
     File.should be_file(Rails.root.join("public/javascripts/bitsnpieces.js"))
   end
 
+  it "exports with multiple conditions to a JS file per available locale" do
+    set_config "multiple_conditions_per_locale.yml"
+
+    result = SimplesIdeias::I18n.translation_segments
+    result.keys.should == ["public/javascripts/i18n/bits.en.js", "public/javascripts/i18n/bits.fr.js"]
+
+    %w{en fr}.each do |lang|
+      result["public/javascripts/i18n/bits.#{lang}.js"].keys.should == [lang.to_sym]
+      result["public/javascripts/i18n/bits.#{lang}.js"][lang.to_sym].keys.sort.should == [:date, :number]
+    end
+  end
+
   it "filters translations using scope *.date.formats" do
     result = SimplesIdeias::I18n.filter(translations, "*.date.formats")
     result[:en][:date].keys.should == [:formats]
@@ -213,4 +225,3 @@ describe SimplesIdeias::I18n do
     SimplesIdeias::I18n.translations
   end
 end
-

--- a/spec/resources/multiple_conditions_per_locale.yml
+++ b/spec/resources/multiple_conditions_per_locale.yml
@@ -1,0 +1,6 @@
+# Find more details about this configuration file at http://github.com/fnando/i18n-js
+translations:
+  - file: "public/javascripts/i18n/bits.%{locale}.js"
+    only:
+      - "date.formats"
+      - "number.currency"


### PR DESCRIPTION
I consider it a bug, because it is documented, but it doesn't work.

> ```
> translations:
> - file: "public/javascripts/i18n/%{locale}.js"
>  only: '*'
> - file: "public/javascripts/frontend/i18n/%{locale}.js"
>  only: ['frontend', 'users']
> ```
