### PR TITLE
Fallback on dates

### DIFF
--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -99,6 +99,25 @@ describe("I18n.js", function(){
 
       "nb": {
         hello: "Hei Verden!"
+      },
+
+      "es": {
+        date: {
+          formats: {
+            "default": "%d/%m/%Y",
+            "short": "%d de %B",
+            "long": "%d de %B de %Y"
+          },
+            day_names: ["Domingo", "Lunes", "Martes", "Miercoles", "Jueves", "Viernes", "Sabado"],
+            abbr_day_names: ["Dom", "Lun", "Mar", "Mie", "Jue", "Vie", "Sab"],
+            month_names: [null, "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Setiembre", "Octubre", "Noviembre", "Diciembre"],
+            abbr_month_names: [null, "Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dec"]
+        }
+      },
+      "es-PE": {
+        date: {
+          month_names: [null]
+        }
       }
     };
   });
@@ -611,6 +630,13 @@ describe("I18n.js", function(){
     expect(I18n.l("date.formats.default", "2009-11-29")).toBeEqualTo("29/11/2009");
     expect(I18n.l("date.formats.short", "2009-01-07")).toBeEqualTo("07 de Janeiro");
     expect(I18n.l("date.formats.long", "2009-01-07")).toBeEqualTo("07 de Janeiro de 2009");
+  });
+
+  specify("localize date string with fallbacks", function(){
+    I18n.locale = "es-PE";
+    I18n.fallbacks = true;
+
+    expect(I18n.l("date.formats.short", "2009-01-07")).toBeEqualTo("07 de Enero");
   });
 
   specify("localize time strings", function(){

--- a/vendor/assets/javascripts/i18n.js
+++ b/vendor/assets/javascripts/i18n.js
@@ -119,8 +119,15 @@ I18n.lookup = function(scope, options) {
   }
 
   if (scope === 'date') {
-    if (I18n.fallbacks && messages.month_names.length < 2) {
-      messages = null;
+    if (I18n.fallbacks) {
+      var fall = false;
+      // optimally it should only fill in for the parts that are missing
+      // but for now just try to fallback if anything is missing
+      if (!messages.day_names || messages.day_names < 2) fall = true;
+      if (!messages.abbr_day_names || messages.abbr_day_names < 2) fall = true;
+      if (!messages.month_names || messages.month_names < 2) fall = true;
+      if (!messages.abbr_month_names || messages.abbr_month_names < 2) fall = true;
+      if (fall) messages = null;
     }
   }
 


### PR DESCRIPTION
When I18n cannot find the localisations for dates in the current locale it should try to fallback to the default locale. For example

if current locale is es-PE but it doesnt have day_names, i18n should try to lookup the day names in 'es' or the default locale. 

This PR is a bit of an improvement but optimally it should lookup only the values that are missing.
