### PR TITLE
Set defaultLocale and locale values from Rails' I18n module

### DIFF
--- a/vendor/assets/javascripts/i18n/translations.js.erb
+++ b/vendor/assets/javascripts/i18n/translations.js.erb
@@ -7,3 +7,5 @@ I18n.translations = <%=
     translations.merge!(segment)
   end.to_json
 %>;
+I18n.defaultLocale = "<%= I18n.default_locale %>";
+I18n.locale = "<%= I18n.locale %>";


### PR DESCRIPTION
Move the rather awkward looking

``` javascript
I18n.defaultLocale = "<%= I18n.default_locale %>";
I18n.locale = "<%= I18n.locale %>";
```

configuration [mentioned in the readme](https://github.com/fnando/i18n-js#on-the-javascript) into the gem itself. It is rather unnecessary to require this configuration, since most use cases probably will configure this the exact same way - and it can still be overwritten.
