### PR TITLE
Fix multiple conditions bug

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -30,7 +30,15 @@ module I18n
 
     def self.segments_per_locale(pattern, scope)
       I18n.available_locales.each_with_object({}) do |locale, segments|
-        result = scoped_translations("#{locale}.#{scope}")
+        if scope.class == Array
+          result = {}
+          scope.each do |s|
+            result.deep_merge!(scoped_translations("#{locale}.#{s}"))
+          end
+        else
+          result = scoped_translations("#{locale}.#{scope}")
+        end
+        
         next if result.empty?
 
         segment_name = ::I18n.interpolate(pattern,{:locale => locale})

--- a/spec/fixtures/js_file_per_locale_multiple_conditions.yml
+++ b/spec/fixtures/js_file_per_locale_multiple_conditions.yml
@@ -1,0 +1,5 @@
+translations:
+  - file: "tmp/i18n-js/%{locale}.js"
+    only: 
+      - "date.formats"
+      - "number.currency"

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -51,6 +51,14 @@ describe I18n::JS do
 
       file_should_exist "bitsnpieces.js"
     end
+
+    it "exports to a JS file per available locale, with multiple conditions" do
+      set_config "js_file_per_locale_multiple_conditions.yml"
+      I18n::JS.export
+
+      file_should_exist "en.js"
+      file_should_exist "fr.js"
+    end
   end
 
   context "filters" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "json"
 
 require "active_support/all"
 require "i18n/js"
+require "yaml"
 
 module Helpers
   # Set the configuration as the current one
@@ -36,6 +37,7 @@ RSpec.configure do |config|
     FileUtils.rm_rf(temp_path)
   end
 
+  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.include Helpers
 end
 


### PR DESCRIPTION
This adds support for multiple conditions when exporting individual JS
files per locale.  Previously, only one condition was supported, now an
array of conditions is also supported.
Test included :sunglasses: 
