### PR TITLE
Add `default` parameter for missing scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ You can set default values for missing scopes:
     // with interpolation
     I18n.t("noun", {defaultValue: "I'm a {{noun}}", noun: "Mac"});
 
+You can also provide a list of default fallbacks for missing scopes:
+
+    // As a scope
+    I18n.t("some.missing.scope", {defaults: [{scope: "some.existing.scope"}]});
+
+    // As a simple translation
+    I18n.t("some.missing.scope", {defaults: [{message: "some.existing.scope"}]});
+
+    Default values must be provided as an array of hashs where the key is the
+    type of translation desired, a `scope` or a `message`. The translation returned
+    will be either the first scope recognized, or the first message defined.
+
+    The translation will fallback to the `defaultValue` translation if no scope
+    in `defaults` matches and if no default of type `message` is found.
+
 Translation fallback can be enabled by enabling the `I18n.fallbacks` option:
 
     <script type="text/javascript">

--- a/app/assets/javascripts/i18n/shims.js
+++ b/app/assets/javascripts/i18n/shims.js
@@ -91,3 +91,29 @@ if ( !Array.prototype.forEach ) {
     // 8. return undefined
   };
 }
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some
+if (!Array.prototype.some)
+{
+  Array.prototype.some = function(fun /*, thisArg */)
+  {
+    'use strict';
+
+    if (this === void 0 || this === null)
+      throw new TypeError();
+
+    var t = Object(this);
+    var len = t.length >>> 0;
+    if (typeof fun !== 'function')
+      throw new TypeError();
+
+    var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+    for (var i = 0; i < len; i++)
+    {
+      if (i in t && fun.call(thisArg, t[i], i, t))
+        return true;
+    }
+
+    return false;
+  };
+}

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -82,6 +82,44 @@ describe("Translate", function(){
     expect(I18n.t("hello")).toEqual("Hei Verden!");
   });
 
+  describe("when provided default valutes", function() {
+    it("uses scope provided in defaults if scope doesn't exist", function() {
+      actual = I18n.t("Hello!", {defaults: [{scope: "greetings.stranger"}]});
+      expect(actual).toEqual("Hello stranger!");
+    });
+
+    it("continues to fallback until a scope is found", function() {
+      var defaults = [{scope: "foo"}, {scope: "hello"}];
+
+      actual = I18n.t("foo", {defaults: defaults});
+      expect(actual).toEqual("Hello World!");
+    });
+
+    it("uses message if specified as a default", function() {
+      var defaults = [{message: "Hello all!"}];
+      actual = I18n.t("foo", {defaults: defaults});
+      expect(actual).toEqual("Hello all!");
+    });
+
+    it("uses the first message if no scopes are found", function() {
+      var defaults = [
+          {scope: "bar"}
+        , {message: "Hello all!"}
+        , {scope: "hello"}];
+      actual = I18n.t("foo", {defaults: defaults});
+      expect(actual).toEqual("Hello all!");
+    });
+
+    it("uses default value if no scope is found", function() {
+      var options = {
+          defaults: [{scope: "bar"}]
+        , defaultValue: "Hello all!"
+      };
+      actual = I18n.t("foo", options);
+      expect(actual).toEqual("Hello all!");
+    });
+  });
+
   it("uses default value for simple translation", function(){
     actual = I18n.t("warning", {defaultValue: "Warning!"});
     expect(actual).toEqual("Warning!");


### PR DESCRIPTION
Hi,

The library currently provides an option for providing `defaultValue` if the provided scope is missing.

Rails provides the ability to specify a default scope in addition to a default value:
`I18n.t :missing, default: [:also_missing, 'Not here']` (http://guides.rubyonrails.org/i18n.html#bulk-and-namespace-lookup)

Would you be interested in a pull request for this?
