### PR TITLE
Add "namespace" option to i18n-js.yml

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -4,6 +4,7 @@ require "fileutils"
 module I18n
   module JS
     require "i18n/js/dependencies"
+    require "i18n/js/segment"
     if JS::Dependencies.rails?
       require "i18n/js/middleware"
       require "i18n/js/engine"
@@ -23,18 +24,14 @@ module I18n
     # Export translations to JavaScript, considering settings
     # from configuration file
     def self.export
-      translation_segments.each do |filename, translations|
-        save(translations, filename)
-      end
+      translation_segments.each(&:save!)
     end
 
-    def self.segments_per_locale(pattern, scope)
-      I18n.available_locales.each_with_object({}) do |locale, segments|
+    def self.segments_per_locale(pattern, scope, namespace)
+      I18n.available_locales.each_with_object([]) do |locale, segments|
         result = scoped_translations("#{locale}.#{scope}")
         next if result.empty?
-
-        segment_name = ::I18n.interpolate(pattern,{:locale => locale})
-        segments[segment_name] = result
+        segments << Segment.new(::I18n.interpolate(pattern,{:locale => locale}), result, namespace)
       end
     end
 
@@ -47,14 +44,15 @@ module I18n
     end
 
     def self.configured_segments
-      config[:translations].each_with_object({}) do |options, segments|
+      config[:translations].inject([]) do |segments, options|
         options.reverse_merge!(:only => "*")
         if options[:file] =~ ::I18n::INTERPOLATION_PATTERN
-          segments.merge!(segments_per_locale(options[:file], options[:only]))
+          segments += segments_per_locale(options[:file], options[:only], options[:namespace])
         else
           result = segment_for_scope(options[:only])
-          segments[options[:file]] = result unless result.empty?
+          segments << Segment.new(options[:file], result, options[:namespace]) unless result.empty?
         end
+        segments
       end
     end
 
@@ -64,7 +62,7 @@ module I18n
 
     def self.filtered_translations
       {}.tap do |result|
-        translation_segments.each do |filename, translations|
+        translation_segments.each do |file, translations|
           deep_merge!(result, translations)
         end
       end
@@ -74,7 +72,7 @@ module I18n
       if config? && config[:translations]
         configured_segments
       else
-        {"#{export_dir}/translations.js" => translations}
+        [Segment.new("#{export_dir}/translations.js", translations)]
       end
     end
 
@@ -91,18 +89,6 @@ module I18n
     # Check if configuration file exist
     def self.config?
       File.file? config_file
-    end
-
-    # Convert translations to JSON string and save file.
-    def self.save(translations, file)
-      FileUtils.mkdir_p File.dirname(file)
-
-      File.open(file, "w+") do |f|
-        f << %(I18n.translations || (I18n.translations = {});\n)
-        translations.each do |locale, translations_for_locale|
-          f << %(I18n.translations["#{locale}"] = #{translations_for_locale.to_json};\n);
-        end
-      end
     end
 
     def self.scoped_translations(scopes) # :nodoc:

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -47,11 +47,11 @@ module I18n
     def self.configured_segments
       config[:translations].inject([]) do |segments, options|
         options.reverse_merge!(:only => "*")
-        if options[:file] =~ ::I18n::INTERPOLATION_PATTERN
-          segments += segments_per_locale(options[:file], options[:only], options[:namespace])
+        if options[:file_path] =~ ::I18n::INTERPOLATION_PATTERN
+          segments += segments_per_locale(options[:file_path], options[:only], options[:namespace])
         else
           result = segment_for_scope(options[:only])
-          segments << Segment.new(options[:file], result, options[:namespace]) unless result.empty?
+          segments << Segment.new(options[:file_path], result, options[:namespace]) unless result.empty?
         end
         segments
       end
@@ -63,7 +63,7 @@ module I18n
 
     def self.filtered_translations
       {}.tap do |result|
-        translation_segments.each do |file, translations|
+        translation_segments.each do |file_path, translations|
           deep_merge!(result, translations)
         end
       end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -1,0 +1,25 @@
+module I18n
+  module JS
+    class Segment
+      attr_accessor :file, :translations, :namespace
+
+      def initialize(file, translations, namespace = nil)
+        @file         = file
+        @translations = translations
+        @namespace    = namespace || 'I18n'
+      end
+
+      # Convert translations to JSON string and saves file
+      def save!
+        FileUtils.mkdir_p File.dirname(self.file)
+
+        File.open(self.file, "w+") do |f|
+          f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
+          self.translations.each do |locale, translations_for_locale|
+            f << %(#{self.namespace}.translations["#{locale}"] = #{translations_for_locale.to_json};\n);
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -1,19 +1,19 @@
 module I18n
   module JS
     class Segment
-      attr_accessor :file, :translations, :namespace
+      attr_accessor :file_path, :translations, :namespace
 
-      def initialize(file, translations, namespace = nil)
-        @file         = file
+      def initialize(file_path, translations, namespace = nil)
+        @file_path    = file_path
         @translations = translations
         @namespace    = namespace || 'I18n'
       end
 
       # Convert translations to JSON string and saves file
       def save!
-        FileUtils.mkdir_p File.dirname(self.file)
+        FileUtils.mkdir_p File.dirname(self.file_path)
 
-        File.open(self.file, "w+") do |f|
+        File.open(self.file_path, "w+") do |f|
           f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
           self.translations.each do |locale, translations_for_locale|
             f << %(#{self.namespace}.translations["#{locale}"] = #{translations_for_locale.to_json};\n);

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -13,13 +13,15 @@ describe I18n::JS do
 
     it "exports messages using custom output path" do
       set_config "custom_path.yml"
-      I18n::JS.should_receive(:save).with(translations, "tmp/i18n-js/all.js")
+      I18n::JS::Segment.should_receive(:new).with("tmp/i18n-js/all.js", translations, nil).and_call_original
+      I18n::JS::Segment.any_instance.should_receive(:save!).with(no_args)
       I18n::JS.export
     end
 
     it "sets default scope to * when not specified" do
       set_config "no_scope.yml"
-      I18n::JS.should_receive(:save).with(translations, "tmp/i18n-js/no_scope.js")
+      I18n::JS::Segment.should_receive(:new).with("tmp/i18n-js/no_scope.js", translations, nil).and_call_original
+      I18n::JS::Segment.any_instance.should_receive(:save!).with(no_args)
       I18n::JS.export
     end
 
@@ -43,6 +45,7 @@ describe I18n::JS do
       I18n::JS.export
 
       file_should_exist "en.js"
+      file_should_exist "fr.js"
     end
 
     it "exports with multiple conditions" do
@@ -99,7 +102,7 @@ describe I18n::JS do
     end
 
     it "sets empty hash as configuration when no file is found" do
-      I18n::JS.config?.should be_false
+      I18n::JS.config?.should eql(false)
       I18n::JS.config.should eql({})
     end
   end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe I18n::JS::Segment do
+
+  let(:file)        { "tmp/i18n-js/segment.js" }
+  let(:translations){ { "en" => { "test" => "Test" }, "fr" => { "test" => "Test2" } } }
+  let(:namespace)   { "MyNamespace" }
+  subject { I18n::JS::Segment.new(file, translations, namespace) }
+
+  describe ".new" do
+
+    it "should persist the file path variable" do
+      subject.file.should eql("tmp/i18n-js/segment.js")
+    end
+
+    it "should persist the translations variable" do
+      subject.translations.should eql(translations)
+    end
+
+    it "should persist the namespace variable" do
+      subject.namespace.should eql("MyNamespace")
+    end
+
+    context "when namespace is nil" do
+      let(:namespace){ nil }
+
+      it "should default namespace to `I18n`" do
+        subject.namespace.should eql("I18n")
+      end
+    end
+
+    context "when namespace is not set" do
+      subject { I18n::JS::Segment.new(file, translations) }
+
+      it "should default namespace to `I18n`" do
+        subject.namespace.should eql("I18n")
+      end
+    end
+  end
+
+  describe "#save!" do
+    before { I18n::JS.stub :export_dir => temp_path }
+    before { subject.save! }
+
+    it "should write the file" do
+      file_should_exist "segment.js"
+
+      File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = {"test":"Test"};
+MyNamespace.translations["fr"] = {"test":"Test2"};
+EOF
+    end
+  end
+end


### PR DESCRIPTION
In some cases I'd like to export the I18n keys to a different Javascript namespace than `I18n`, to avoid conflicts. For example, I have a widget-type component which is embedded in third-party websites, and many of these sites already define the `I18n` namespace.

To do this, I have added an optional `:namespace` key to `i18n-js.yml`, which can be set per file.

Example:

```yaml
translations:
  - file: "tmp/i18n-js/without_namespace.js"
    only: "*"
  - file: "tmp/i18n-js/with_namespace.js"
    namespace: "MyNamespace"
    only: "*"
```

This generates:

```js
// tmp/i18n-js/with_namespace.js

MyNamespace.translations || (MyNamespace.translations = {});
MyNamespace.translations["en"] = {"test":"Test"};
MyNamespace.translations["fr"] = {"test":"Test2"};
```

In theory this should be a small change to implement, but the `js.rb` (exporter) code is written in a tightly-coupled fashion. I've refactored the code to extract a `Segment` class, which is extensible in case we'd like to add other similar options in the future. All tests are passing, and I've added additional tests specific to the new `Segment` class.

Note that I have not touched the Javascript here, only the Ruby-based exporter code. (JS could be a separate PR)