### PR TITLE
added 'guess' option for missing translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+- You can now set `I18n.missingBehavior='guess'` to have the scope string output as text instead of of the
+  "[missing `scope`]" message when no translation is available
+
 ### enhancements
 
 - You can now assign `I18n.locale` & `I18n.default_locale` before loading `i18n.js` in `application.html.*`

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ are three different ways of doing it so:
     I18n.locales.no = "nb";
     I18n.locales.no = function(locale){ return ["nb"]; };
 
+If a translation is missing the default displayed message will be
+[missing "name of scope" translation]
+While you are developing or if you do not want to provide a translation 
+in the default language you can set
+
+    I18n.missingBehavior='guess';
+    
+this will take the last section of your scope and guess the intended value
+camel case becomes lower cased text and undersocres are repplaced with space
+questionnaire.whatIsYourFavorite_ChristmasPresent becomes
+"what is your favorite Christmas present"
+
 Pluralization is possible as well and by default provides English rules:
 
     I18n.t("inbox.counting", {count: 10}); // You have 10 messages

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ are three different ways of doing it so:
     I18n.locales.no = "nb";
     I18n.locales.no = function(locale){ return ["nb"]; };
 
-If a translation is missing the default displayed message will be
+By default a missing translation will be displayed as
 [missing "name of scope" translation]
 While you are developing or if you do not want to provide a translation 
 in the default language you can set
@@ -194,8 +194,10 @@ in the default language you can set
     
 this will take the last section of your scope and guess the intended value
 camel case becomes lower cased text and undersocres are repplaced with space
-questionnaire.whatIsYourFavorite_ChristmasPresent becomes
-"what is your favorite Christmas present"
+
+    questionnaire.whatIsYourFavorite_ChristmasPresent
+
+becomes "what is your favorite Christmas present"
 
 Pluralization is possible as well and by default provides English rules:
 

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -76,7 +76,7 @@
     translations: {},
     // Set missing translation behavior. 'message' will display a message
     // that the translation is missing, 'guess' will try to guess the string
-    defaultBahavior: 'message',
+    missingBahavior: 'message',
   }
 
   I18n.reset = function() {

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -60,55 +60,35 @@
 
   // Other default options
   var DEFAULT_OPTIONS = {
+    // Set default locale. This locale will be used when fallback is enabled and
+    // the translation doesn't exist in a particular locale.
     defaultLocale: "en",
+    // Set the current locale to `en`.
     locale: "en",
+    // Set the translation key separator.
     defaultSeparator: ".",
+    // Set the placeholder format. Accepts `{{placeholder}}` and `%{placeholder}`.
     placeholder: /(?:\{\{|%\{)(.*?)(?:\}\}?)/gm,
+    // Set if engine should fallback to the default locale when a translation
+    // is missing.
     fallbacks: false,
+    // Set the default translation object.
     translations: {},
+    // Set missing translation behavior. 'message' will display a message
+    // that the translation is missing, 'guess' will try to guess the string
+    defaultBahavior: 'message',
   }
 
   I18n.reset = function() {
-    // Set default locale. This locale will be used when fallback is enabled and
-    // the translation doesn't exist in a particular locale.
-    this.defaultLocale = DEFAULT_OPTIONS.defaultLocale;
-
-    // Set the current locale to `en`.
-    this.locale = DEFAULT_OPTIONS.locale;
-
-    // Set the translation key separator.
-    this.defaultSeparator = DEFAULT_OPTIONS.defaultSeparator;
-
-    // Set the placeholder format. Accepts `{{placeholder}}` and `%{placeholder}`.
-    this.placeholder = DEFAULT_OPTIONS.placeholder;
-
-    // Set if engine should fallback to the default locale when a translation
-    // is missing.
-    this.fallbacks = DEFAULT_OPTIONS.fallbacks;
-
-    // Set the default translation object.
-    this.translations = DEFAULT_OPTIONS.translations;
+    for(var prop in DEFAULT_OPTIONS)
+      this[prop] = DEFAULT_OPTIONS[prop];
   };
 
   // Much like `reset`, but only assign options if not already assigned
   I18n.initializeOptions = function() {
-    if (typeof(this.defaultLocale) === "undefined" && this.defaultLocale !== null)
-      this.defaultLocale = DEFAULT_OPTIONS.defaultLocale;
-
-    if (typeof(this.locale) === "undefined" && this.locale !== null)
-      this.locale = DEFAULT_OPTIONS.locale;
-
-    if (typeof(this.defaultSeparator) === "undefined" && this.defaultSeparator !== null)
-      this.defaultSeparator = DEFAULT_OPTIONS.defaultSeparator;
-
-    if (typeof(this.placeholder) === "undefined" && this.placeholder !== null)
-      this.placeholder = DEFAULT_OPTIONS.placeholder;
-
-    if (typeof(this.fallbacks) === "undefined" && this.fallbacks !== null)
-      this.fallbacks = DEFAULT_OPTIONS.fallbacks;
-
-    if (typeof(this.translations) === "undefined" && this.translations !== null)
-      this.translations = DEFAULT_OPTIONS.translations;
+    for(var prop in DEFAULT_OPTIONS)
+      if (typeof(this[prop]) === "undefined" && this[prop] !== null)
+        this[prop] = DEFAULT_OPTIONS[prop];
   }
   I18n.initializeOptions();
 
@@ -450,6 +430,16 @@
 
   // Return a missing translation message for the given parameters.
   I18n.missingTranslation = function(scope) {
+    //guess intended string
+    if(this.missingBehavior == 'guess'){
+      //get only the last portion of the scope
+      var s = scope.split('.').slice(-1)[0];
+      //replace underscore with space && camelcase with space and lowercase letter
+      return s.replace('_',' ').replace(/([a-z])([A-Z])/g,
+        function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
+    }
+    
+    //default
     var message = '[missing "';
 
     message += this.currentLocale() + ".";


### PR DESCRIPTION
Added option missingBehavior, which avoids to have to create strings when developing or simple strings that do not need a declaration in the default language.

- move options comments at declaring array, as this is the right place
- recursive declaration of reset and initializeOptions
- added 'missingBehavior' option with possible values 'message' (or anything else) keeping the actual behavior, 'guess' tries to create a readable string