### PR TITLE
Fixes an issue which doesn't update assets cache with rails 4

### DIFF
--- a/lib/i18n/js/engine.rb
+++ b/lib/i18n/js/engine.rb
@@ -4,24 +4,14 @@ module I18n
   module JS
     class Engine < ::Rails::Engine
       initializer :after => "sprockets.environment" do
-        ActiveSupport.on_load(:after_initialize, :yield => true) do
-          next unless JS::Dependencies.using_asset_pipeline?
-          next unless Rails.configuration.assets.compile
+        next unless JS::Dependencies.using_asset_pipeline?
+        next unless Rails.configuration.assets.compile
 
-          begin
-            Rails.application.assets.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
-              if context.logical_path == "i18n/filtered"
-                ::I18n.load_path.each {|path| context.depend_on(File.expand_path(path))}
-              end
-
-              source
-            end
-          rescue TypeError # I don't think there is a more specific error to rescue
-            # Could be raised by `Sprockets::Index`/`Sprockets::CachedEnvironment`
-            # when doing `register_preprocessor` (which calls `expire_cache!` somehow)
-            #
-            # In that case it is immutable, we don't need to do anything
+        Rails.application.assets.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
+          if context.logical_path == "i18n/filtered"
+            ::I18n.load_path.each {|path| context.depend_on(File.expand_path(path))}
           end
+          source
         end
       end
     end


### PR DESCRIPTION
What was happening:
1. Rails.application.assets.register_preprocessor was always raising
TypeError: can't modify immutable index.
2. The error was rescued so looks it's done. But context.depend_on is
not registered so locale files changes didn't expires cache.

I found
https://github.com/rails/rails/issues/2211#issuecomment-1724180
and simply removed ActiveSupport.on_load (and the rescue) and everything
is working well.
