### PR TITLE
Add bower.json to enable consumption through bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "i18n-js",
+  "version": "2.1.2",
+  "homepage": "https://github.com/fnando/i18n-js/",
+  "authors": [
+    "Nando Vieira"
+  ],
+  "description": "It's a small library to provide the I18n translations on the Javascript. It comes with Rails support.",
+  "main": "app/assets/javascripts/i18n.js",
+  "keywords": [
+    "i18n",
+    "translation",
+    "internationalization"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
With this it is possible to use this repo through bower with:

```
bower install https://github.com/fnando/i18n-js.git
```

You could also publish the repo to the bower repository (to get rid of the full repo path) with:

```
bower register <my-package-name> <git-endpoint>
```

Closes #216
