### PR TITLE
Changing Readme to include requirement of i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you're using the [asset pipeline](http://guides.rubyonrails.org/asset_pipelin
 then you must add the following line to your `app/assets/javascripts/application.js`.
 
 ```javascript
+//= require i18n
 //= require i18n/translations
 ```
 


### PR DESCRIPTION
In the topic Rails app without Asset Pipeline `i18n.js` is loaded along with the `translations.js` file. (`<%= javascript_include_tag "i18n", "translations" %>`). 

In the Rails app with Asset Pipeline the instructions tell to only load `i18n/translations`. You should load before the `i18n` with the `//= require i18n` directive. 

I don't now if this is on purpose (like every rails guy should now this) bu it wasn't clear for a noob like me ;)
