### PR TITLE
Explicitly requiring i18n necessary?

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ If you're using the [asset pipeline](http://guides.rubyonrails.org/asset_pipelin
 then you must add the following line to your `app/assets/javascripts/application.js`.
 
 ```javascript
-// The following line will include `i18n` library already
-// No need to put `//= require i18n`
+//= require i18n
 //= require i18n/translations
 ```
 


### PR DESCRIPTION
I have included this gem a few places and have had to explicitly include the `//=require i18n` line in my application.js file in order to gain access to the `t` function on the I18n object. Otherwise, you have to get at the translations with syntax such as: `I18n.translations.en.etc.etc`. Could totally be some quirk on my setup (Rails, Angular) - but figured I would open a PR/Discussion in case this affected anyone else.

Cheers :)
