### PR TITLE
Add defaultScope to global config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,11 @@ You can also provide an array as scope.
     // use the greetings.hello scope
     I18n.t(["greetings", "hello"]);
 
+Default scope can also be configured globally.
+
+    I18n.defaultScope = "activerecord.attributes";
+    I18n.t("user.name");
+
 #### Number formatting
 
 Similar to Rails helpers, you have localized number and currency formatting.

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -100,6 +100,8 @@
     // string is actually missing for testing purposes, you can prefix the
     // guessed string by setting the value here. By default, no prefix!
     , missingTranslationPrefix: ''
+    // Set default scope for all I18n keys.
+    , defaultScope: null
   };
 
   I18n.reset = function() {
@@ -129,6 +131,8 @@
     // Set the default missing string prefix for guess behaviour
     this.missingTranslationPrefix = DEFAULT_OPTIONS.missingTranslationPrefix;
 
+    // Set the default scope to null
+    this.defaultScope = DEFAULT_OPTIONS.defaultScope;
   };
 
   // Much like `reset`, but only assign options if not already assigned
@@ -375,6 +379,13 @@
     if (this.isSet(options.defaultValue)) {
       translationOptions.push({ message: options.defaultValue });
       delete options.defaultValue;
+    }
+
+    // Add defaultScope.scope too lookup array
+    if (!this.isSet(options.scope) && I18n.defaultScope) {
+      translationOptions.push({
+        scope: I18n.defaultScope.concat(I18n.defaultSeparator, scope)
+      });
     }
 
     return translationOptions;

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -205,4 +205,14 @@ describe("Translate", function(){
   it("accepts the scope as an array using a base scope", function(){
     expect(I18n.t(["stranger"], {scope: "greetings"})).toEqual("Hello stranger!");
   });
+
+  it("uses default scope when configured", function(){
+    I18n.defaultScope = "greetings";
+    expect(I18n.t("stranger")).toEqual("Hello stranger!");
+  });
+
+  it("prioritizes custom scope over default", function(){
+    I18n.defaultScope = "other";
+    expect(I18n.t("stranger", {scope: "greetings"})).toEqual("Hello stranger!");
+  });
 });


### PR DESCRIPTION
As requested [here](https://github.com/fnando/i18n-js/issues/232) it will add defaultScope global setting that would allow skipping providing the same scope value over and over again. So instead of doing 

```
I18n.t("name", {scope: "activerecord.attributes.user"});
I18n.t("email", {scope: "activerecord.attributes.user"});
```

or

```
var defaults = {scope: "activerecord.attributes.user"};
I18n.t("name", defaults);
I18n.t("email", defaults);
```

we could simply:

```
I18n.defaultScope = "activerecord.attributes.user";
I18n.t("name");
I18n.t("email");
```

What do you think?
