### PR TITLE
2.x - Fix permission of i18njs-cache

### DIFF
--- a/lib/i18n-js/engine.rb
+++ b/lib/i18n-js/engine.rb
@@ -53,6 +53,8 @@ module SimplesIdeias
         File.open(load_path_hash_cache, "w+") do |f|
           f.write(cached_load_path_hash)
         end
+
+        File.chmod(0777, 'tmp/i18n-js.cache')
       end
 
       class << self


### PR DESCRIPTION
Please fix. This is breaking our dev environment and deployments.

Thanks.