### PR TITLE
The default configuration before I18n is loaded is not working

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -15,21 +15,21 @@
 ;(function(factory) {
   if (typeof module !== 'undefined') {
     // Node/CommonJS
-    module.exports = factory();
+    module.exports = factory(this);
 
   } else if (typeof define === 'function' && define.amd) {
     // AMD
-    define(factory);
+    define((function(global){ return function(){ factory(global); }})(this));
 
   } else {
     // Browser globals
-    this.I18n = factory();
+    this.I18n = factory(this);
   }
-}(function() {
+}(function(global) {
   "use strict";
 
   // Use previously defined object if exists in current scope
-  var I18n = this && this.I18n || {};
+  var I18n = global && global.I18n || {};
 
   // Just cache the Array#slice function.
   var slice = Array.prototype.slice;


### PR DESCRIPTION
Because `"use strict"` is called at the first place of the function, `this` in the function will be `undefined` and then the default configuration below is not working.

``` js
I18n = {} // You must define this object in top namespace, which should be `window`
I18n.defaultLocale = "pt-BR";
I18n.locale = "pt-BR";

// Load I18n from `i18n.js`, `application.js` or whatever

I18n.currentLocale();
// pt-BR
```

I fixed by passing the global object to the function
