### PR TITLE
Interpolate empty string rather than error message for explicit null

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -424,6 +424,8 @@
 
       if (this.isSet(options[name])) {
         value = options[name].toString().replace(/\$/gm, "_#$#_");
+      } else if (name in options) {
+        value = "";
       } else {
         value = this.missingPlaceholder(placeholder, message);
       }

--- a/spec/js/interpolation.spec.js
+++ b/spec/js/interpolation.spec.js
@@ -29,5 +29,10 @@ describe("Interpolation", function(){
   it("outputs missing placeholder message if interpolation value is missing", function(){
     actual = I18n.t("greetings.name");
     expect(actual).toEqual("Hello [missing {{name}} value]!");
-  })
+  });
+
+  it("handles explicit null values", function(){
+    actual = I18n.t("greetings.name", {name: null});
+    expect(actual).toEqual("Hello !");
+  });
 });


### PR DESCRIPTION
In interpolating a string, if a placeholder isn't passed in the options at all, showing an error message is appropriate. If the placeholder is passed and its value is null, though, I think it's better to just use the empty string. This avoids showing a cryptic error message to end users.
