### PR TITLE
ensure I18n is initialized for Node/CommonJS only when the environment is a Node/CommonJS env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### bug fixes
 
+- Fix factory initialization so that the Node/CommonJS branch only gets executed if the environment is Node/CommonJS
+  (it currently will execute if module is defined in the global scope, which occurs with QUnit, for example)
 - Fix pluralization rules selection for negative `count` (e.g. `-1` was lead to use `one` for pluralization) ([#268](https://github.com/fnando/i18n-js/pull/268))
 - Remove check for `Rails.configuration.assets.compile` before telling Sprockets the dependency of translations JS file  
   This might be the reason of many "cache not expired" issues  

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -13,7 +13,7 @@
 //
 
 ;(function(factory) {
-  if (typeof module !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
     // Node/CommonJS
     module.exports = factory(this);
 


### PR DESCRIPTION
@fnando please review

Without this fix, developers cannot use QUnit alongside i18n because QUnit defines `window.module`.

I noticed there aren't currently any tests for the Node/CommonJS vs. AMD vs. browser globals branches in the factory initialization section. Testing it would also involve some non-trivial refactoring of the specs since i18n.js is required before any tests and uses an IIFE to load the library...happy to help with that if you'd like, but this is a pretty minor change that is the default way of checking for Node, for example:

https://github.com/jashkenas/underscore/blob/181595137307d53d5781c428e78f2573012bdd16/underscore.js#L45
https://github.com/moment/momentjs.com/blob/9d6d3c663b0c6e2cd358280eac10862cbaad1859/libs/nodeunit/nodeunit.js#L508
