### PR TITLE
Add forgotten return statement

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -19,7 +19,7 @@
 
   } else if (typeof define === 'function' && define.amd) {
     // AMD
-    define((function(global){ return function(){ factory(global); }})(this));
+    define((function(global){ return function(){ return factory(global); }})(this));
 
   } else {
     // Browser globals


### PR DESCRIPTION
Otherwise `I18n` module will not get registered by AMD.
