### PR TITLE
Allow forcing currency number sign to be at first place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   Set to `function() {return "";}` to match Ruby `I18n.t("name: %{name}", name: nil)`
 - For date formatting, you can now also add placeholders to the date format, see README for detail
 - Add fallbacks option to `i18n-js.yml`, defaults to `true`
+- Force currency number sign to be at first place using `sign_first` option, default to `true`
 
 ### bug fixes
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ The `toCurrency` function accepts the following options:
 - `format`: sets the format of the output string
 - `unit`: sets the denomination of the currency
 - `strip_insignificant_zeros`: defaults to `false`
+- `sign_first`: defaults to `true`
 
 You can provide only the options you want to override:
 

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -61,13 +61,16 @@
       unit: "$"
     , precision: 2
     , format: "%u%n"
+    , sign_first: true
     , delimiter: ","
     , separator: "."
   };
 
   // Set default percentage format.
   var PERCENTAGE_FORMAT = {
-      precision: 3
+      unit: "%"
+    , precision: 3
+    , format: "%n%u"
     , separator: "."
     , delimiter: ""
   };
@@ -514,6 +517,8 @@
       , precision
       , buffer = []
       , formattedNumber
+      , format = options.format || "%n"
+      , sign = negative ? "-" : ""
     ;
 
     number = parts[0];
@@ -534,9 +539,18 @@
       formattedNumber += options.separator + precision;
     }
 
-    if (negative) {
-      formattedNumber = "-" + formattedNumber;
+    if (options.sign_first) {
+      format = "%s" + format;
     }
+    else {
+      format = format.replace("%n", "%s%n");
+    }
+
+    formattedNumber = format
+      .replace("%u", options.unit)
+      .replace("%n", formattedNumber)
+      .replace("%s", sign)
+    ;
 
     return formattedNumber;
   };
@@ -564,13 +578,7 @@
       , CURRENCY_FORMAT
     );
 
-    number = this.toNumber(number, options);
-    number = options.format
-      .replace("%u", options.unit)
-      .replace("%n", number)
-    ;
-
-    return number;
+    return this.toNumber(number, options);
   };
 
   // Localize several values.
@@ -782,8 +790,7 @@
       , PERCENTAGE_FORMAT
     );
 
-    number = this.toNumber(number, options);
-    return number + "%";
+    return this.toNumber(number, options);
   };
 
   // Convert a number into a readable size representation.
@@ -810,16 +817,10 @@
 
     options = this.prepareOptions(
         options
-      , {precision: precision, format: "%n%u", delimiter: ""}
+      , {unit: unit, precision: precision, format: "%n%u", delimiter: ""}
     );
 
-    number = this.toNumber(size, options);
-    number = options.format
-      .replace("%u", unit)
-      .replace("%n", number)
-    ;
-
-    return number;
+    return this.toNumber(size, options);
   };
 
   // Set aliases, so we can save some typing.

--- a/spec/js/currency.spec.js
+++ b/spec/js/currency.spec.js
@@ -13,6 +13,7 @@ describe("Currency", function(){
   it("formats currency with default settings", function(){
     expect(I18n.toCurrency(100.99)).toEqual("$100.99");
     expect(I18n.toCurrency(1000.99)).toEqual("$1,000.99");
+    expect(I18n.toCurrency(-1000)).toEqual("-$1,000.00");
   });
 
   it("formats currency with custom settings", function(){
@@ -56,5 +57,6 @@ describe("Currency", function(){
     expect(I18n.toCurrency(1234, {separator: "-"})).toEqual("$1,234-00");
     expect(I18n.toCurrency(1234, {delimiter: "-"})).toEqual("$1-234.00");
     expect(I18n.toCurrency(1234, {format: "%u %n"})).toEqual("$ 1,234.00");
+    expect(I18n.toCurrency(-123, {sign_first: false})).toEqual("$-123.00");
   });
 });


### PR DESCRIPTION
As description says, f.ex when doing ``I18n.toCurrency(-1000)`` we get ``$-1,000.00`` in result. This issue was raised already there[https://github.com/fnando/i18n-js/issues/286]. Also ruby I18n does it as we would expect, rather than as it's implemented in i18n-js now:
```
number_to_currency(-9800.56, format: '%u%n')
-€9.800,56 
```
I've changed '-' sign to be at first place by default in this PR, which also can be configured using ``sign_first`` in options. What do you think guys?