### PR TITLE
Config options: Namespace, PrettyPrint, and Export I18n JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,20 +110,33 @@ translations:
 ```
 
 #### Export Configuration (For other things)
-- `I18n::JS.config_file_path`  
+
+- `I18n::JS.config_file_path`
   Expected Type: `String`  
   Default: `config/i18n-js.yml`  
   Behaviour: Try to read the config file from that location  
-- `I18n::JS.export_i18n_js_dir_path`  
+
+- `I18n::JS.export_i18n_js_dir_path`
   Expected Type: `String`  
   Default: `public/javascripts`  
   Behaviour:  
   - Any `String`: considered as a relative path for a folder to `Rails.root` and export `i18n.js` to that folder for `rake i18n:js:export`
-  - `nil`: Disable `i18n.js` exporting
+  - Any non-`String` (`nil`, `false`, `:none`, etc): Disable `i18n.js` exporting
+
+- You may also set `export_i18n_js` in your config file, e.g.:
+
+```yaml
+export_i18n_js_: false
+# OR
+export_i18n_js: "my/path"
+
+translations:
+  - ...
+``
 
 To find more examples on how to use the configuration file please refer to the tests.
 
-##### Fallbacks
+#### Fallbacks
 
 If you specify the `fallbacks` option, you will be able to fill missing translations with those inside fallback locale(s).  
 Default value is `true`.
@@ -182,10 +195,41 @@ You must disable this feature by setting the option to `false`.
 To find more examples on how to use the configuration file please refer to the tests.
 
 
+#### Namespace
+
+Setting the `namespace` option will change the namespace of the output Javascript file to something other than `I18n`.
+This can be useful in no-conflict scenarios. Example:
+
+```yaml
+translations:
+- file: "public/javascripts/i18n/translations.js"
+  namespace: "MyNamespace"
+```
+
+will create:
+
+```
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = { ... }
+```
+
+
+#### Pretty Print
+
+Set the `pretty_print` option if you would like whitespace and indentation in your output file (default: false)
+
+```yaml
+translations:
+- file: "public/javascripts/i18n/translations.js"
+  pretty_print: true
+```
+
+
 #### Vanilla JavaScript
 
 Just add the `i18n.js` file to your page. You'll have to build the translations object
 by hand or using your favorite programming language. More info below.
+
 
 #### Via NPM with webpack and CommonJS
 

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -1,6 +1,6 @@
+require "yaml"
 require "i18n"
 require "fileutils"
-
 require "i18n/js/utils"
 
 module I18n
@@ -165,7 +165,7 @@ module I18n
 
       # Copy i18n.js
       def self.export_i18n_js
-        return if export_i18n_js_dir_path.nil?
+        return unless export_i18n_js_dir_path.is_a? String
 
         FileUtils.mkdir_p(export_i18n_js_dir_path)
 
@@ -174,13 +174,14 @@ module I18n
       end
 
       def self.export_i18n_js_dir_path
-        return @export_i18n_js_dir_path if defined?(@export_i18n_js_dir_path)
-
-        @export_i18n_js_dir_path = DEFAULT_EXPORT_DIR_PATH
+        @export_i18n_js_dir_path ||= (config[:export_i18n_js] || :none) if config.has_key?(:export_i18n_js)
+        @export_i18n_js_dir_path ||= DEFAULT_EXPORT_DIR_PATH
+        @export_i18n_js_dir_path
       end
 
       # Setting this to nil would disable i18n.js exporting
       def self.export_i18n_js_dir_path=(new_path)
+        new_path = :none unless new_path.is_a? String
         @export_i18n_js_dir_path = new_path
       end
     end

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -7,6 +7,7 @@ module I18n
   module JS
     require "i18n/js/dependencies"
     require "i18n/js/fallback_locales"
+    require "i18n/js/segment"
     if JS::Dependencies.rails?
       require "i18n/js/middleware"
       require "i18n/js/engine"
@@ -20,6 +21,7 @@ module I18n
     def self.config_file_path
       @config_file_path ||= DEFAULT_CONFIG_PATH
     end
+
     def self.config_file_path=(new_path)
       @config_file_path = new_path
     end
@@ -29,21 +31,17 @@ module I18n
     def self.export
       export_i18n_js
 
-      translation_segments.each do |filename, translations|
-        save(translations, filename)
-      end
+      translation_segments.each(&:save!)
     end
 
-    def self.segments_per_locale(pattern, scope)
-      I18n.available_locales.each_with_object({}) do |locale, segments|
+    def self.segments_per_locale(pattern, scope, options)
+      I18n.available_locales.each_with_object([]) do |locale, segments|
         scope = [scope] unless scope.respond_to?(:each)
         result = scoped_translations(scope.collect{|s| "#{locale}.#{s}"})
         merge_with_fallbacks!(result, locale, scope) if use_fallbacks?
 
         next if result.empty?
-
-        segment_name = ::I18n.interpolate(pattern,{:locale => locale})
-        segments[segment_name] = result
+        segments << Segment.new(::I18n.interpolate(pattern, {:locale => locale}), result, options)
       end
     end
 
@@ -56,21 +54,25 @@ module I18n
     end
 
     def self.configured_segments
-      config[:translations].each_with_object({}) do |options, segments|
-        options.reverse_merge!(:only => "*")
-        if options[:file] =~ ::I18n::INTERPOLATION_PATTERN
-          segments.merge!(segments_per_locale(options[:file], options[:only]))
+      config[:translations].inject([]) do |segments, options|
+        file = options[:file]
+        only = options[:only] || '*'
+        segment_options = options.slice(:namespace, :pretty_print)
+
+        if file =~ ::I18n::INTERPOLATION_PATTERN
+          segments += segments_per_locale(file, only, segment_options)
         else
-          result = segment_for_scope(options[:only])
-          segments[options[:file]] = result unless result.empty?
+          result = segment_for_scope(only)
+          segments << Segment.new(file, result, segment_options) unless result.empty?
         end
+        segments
       end
     end
 
     def self.filtered_translations
       {}.tap do |result|
-        translation_segments.each do |filename, translations|
-          Utils.deep_merge!(result, translations)
+        translation_segments.each do |segment|
+          Utils.deep_merge!(result, segment.translations)
         end
       end
     end
@@ -79,7 +81,7 @@ module I18n
       if config? && config[:translations]
         configured_segments
       else
-        {"#{DEFAULT_EXPORT_DIR_PATH}/translations.js" => translations}
+        [Segment.new("#{DEFAULT_EXPORT_DIR_PATH}/translations.js", translations)]
       end
     end
 
@@ -97,18 +99,6 @@ module I18n
     # Check if configuration file exist
     def self.config?
       File.file? config_file_path
-    end
-
-    # Convert translations to JSON string and save file.
-    def self.save(translations, file)
-      FileUtils.mkdir_p File.dirname(file)
-
-      File.open(file, "w+") do |f|
-        f << %(I18n.translations || (I18n.translations = {});\n)
-        Utils.strip_keys_with_nil_values(translations).each do |locale, translations_for_locale|
-          f << %(I18n.translations["#{locale}"] = #{translations_for_locale.to_json};\n);
-        end
-      end
     end
 
     def self.scoped_translations(scopes) # :nodoc:
@@ -170,9 +160,9 @@ module I18n
       end
     end
 
-
     ### Export i18n.js
     begin
+
       # Copy i18n.js
       def self.export_i18n_js
         return if export_i18n_js_dir_path.nil?
@@ -182,11 +172,13 @@ module I18n
         i18n_js_path = File.expand_path('../../../app/assets/javascripts/i18n.js', __FILE__)
         FileUtils.cp(i18n_js_path, export_i18n_js_dir_path)
       end
+
       def self.export_i18n_js_dir_path
         return @export_i18n_js_dir_path if defined?(@export_i18n_js_dir_path)
 
         @export_i18n_js_dir_path = DEFAULT_EXPORT_DIR_PATH
       end
+
       # Setting this to nil would disable i18n.js exporting
       def self.export_i18n_js_dir_path=(new_path)
         @export_i18n_js_dir_path = new_path

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -1,0 +1,39 @@
+module I18n
+  module JS
+
+    # Class which enscapulates a translations hash and outputs a single JSON translation file
+    class Segment
+      attr_accessor :file, :translations, :namespace, :pretty_print
+
+      def initialize(file, translations, options = {})
+        @file         = file
+        @translations = translations
+        @namespace    = options[:namespace] || 'I18n'
+        @pretty_print = options[:pretty_print]
+      end
+
+      # Saves JSON file containing translations
+      def save!
+        FileUtils.mkdir_p File.dirname(self.file)
+
+        File.open(self.file, "w+") do |f|
+          f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
+          self.translations.each do |locale, translations|
+            f << %(#{self.namespace}.translations["#{locale}"] = #{print_json(translations)};\n);
+          end
+        end
+      end
+
+      protected
+
+      # Outputs pretty or ugly JSON depending on :pretty_print option
+      def print_json(translations)
+        if pretty_print
+          JSON.pretty_generate(translations)
+        else
+          translations.to_json
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -9,7 +9,7 @@ module I18n
         @file         = file
         @translations = translations
         @namespace    = options[:namespace] || 'I18n'
-        @pretty_print = options[:pretty_print]
+        @pretty_print = !!options[:pretty_print]
       end
 
       # Saves JSON file containing translations

--- a/spec/fixtures/js_export_dir_custom.yml
+++ b/spec/fixtures/js_export_dir_custom.yml
@@ -1,0 +1,6 @@
+
+export_i18n_js: 'tmp/i18n-js/foo'
+
+translations:
+  - file: "tmp/i18n-js/%{locale}.js"
+    only: '*'

--- a/spec/fixtures/js_export_dir_none.yml
+++ b/spec/fixtures/js_export_dir_none.yml
@@ -1,0 +1,6 @@
+
+export_i18n_js: false
+
+translations:
+  - file: "tmp/i18n-js/%{locale}.js"
+    only: '*'

--- a/spec/fixtures/js_file_with_namespace_and_pretty_print.yml
+++ b/spec/fixtures/js_file_with_namespace_and_pretty_print.yml
@@ -1,0 +1,5 @@
+translations:
+  - file: "tmp/i18n-js/%{locale}.js"
+    only: '*'
+    namespace: "Foo"
+    pretty_print: true

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -263,7 +263,9 @@ EOS
   end
 
   describe "i18n.js exporting" do
-    describe ".export_i18n_js" do
+    after { begin described_class.send(:remove_instance_variable, :@export_i18n_js_dir_path); rescue; end }
+
+    describe ".export_i18n_js with global variable" do
       before do
         allow(FileUtils).to receive(:mkdir_p).and_call_original
         allow(FileUtils).to receive(:cp).and_call_original
@@ -298,11 +300,47 @@ EOS
       end
     end
 
+    describe ".export_i18n_js with config" do
+
+      let(:export_action) do
+        allow(FileUtils).to receive(:mkdir_p).and_call_original
+        allow(FileUtils).to receive(:cp).and_call_original
+        I18n::JS.export_i18n_js
+      end
+
+      context 'when :export_i18n_js set in config' do
+        before { set_config "js_export_dir_custom.yml"; export_action }
+        let(:export_i18n_js_dir_path) { temp_path }
+        let(:config_export_path) { "tmp/i18n-js/foo" }
+
+        it "does create the folder before copying" do
+          expect(FileUtils).to have_received(:mkdir_p).with(config_export_path).once
+        end
+        it "does copy the file with FileUtils.cp" do
+          expect(FileUtils).to have_received(:cp).once
+        end
+        it "exports the file" do
+          File.should be_file(File.join(config_export_path, "i18n.js"))
+        end
+      end
+
+      context 'when .export_i18n_js_dir_path is set to false' do
+        before { set_config "js_export_dir_none.yml"; export_action }
+
+        it "does NOT create the folder before copying" do
+          expect(FileUtils).to_not have_received(:mkdir_p)
+        end
+
+        it "does NOT copy the file with FileUtils.cp" do
+          expect(FileUtils).to_not have_received(:cp)
+        end
+      end
+    end
 
     describe '.export_i18n_js_dir_path' do
       let(:default_path) { I18n::JS::DEFAULT_EXPORT_DIR_PATH }
       let(:new_path) { File.join("tmp", default_path) }
-      before { described_class.send(:remove_instance_variable, :@export_i18n_js_dir_path) }
+      after { described_class.send(:remove_instance_variable, :@export_i18n_js_dir_path) }
 
       subject { described_class.export_i18n_js_dir_path }
 
@@ -317,7 +355,7 @@ EOS
       context "when it is set to nil already" do
         before { described_class.export_i18n_js_dir_path = nil }
 
-        it { should be_nil }
+        it { should eq :none }
       end
     end
   end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe I18n::JS::Segment do
+
+  let(:file)        { "tmp/i18n-js/segment.js" }
+  let(:translations){ { "en" => { "test" => "Test" }, "fr" => { "test" => "Test2" } } }
+  let(:namespace)   { "MyNamespace" }
+  let(:options)     { {namespace: namespace} }
+  subject { I18n::JS::Segment.new(file, translations, options) }
+
+  describe ".new" do
+
+    it "should persist the file path variable" do
+      subject.file.should eql("tmp/i18n-js/segment.js")
+    end
+
+    it "should persist the translations variable" do
+      subject.translations.should eql(translations)
+    end
+
+    it "should persist the namespace variable" do
+      subject.namespace.should eql("MyNamespace")
+    end
+
+    context "when namespace is nil" do
+      let(:namespace){ nil }
+
+      it "should default namespace to `I18n`" do
+        subject.namespace.should eql("I18n")
+      end
+    end
+
+    context "when namespace is not set" do
+      subject { I18n::JS::Segment.new(file, translations) }
+
+      it "should default namespace to `I18n`" do
+        subject.namespace.should eql("I18n")
+      end
+    end
+  end
+
+  describe "#save!" do
+    before { allow(I18n::JS).to receive(:export_i18n_js_dir_path).and_return(temp_path) }
+    before { subject.save! }
+
+    it "should write the file" do
+      file_should_exist "segment.js"
+
+      File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = {"test":"Test"};
+MyNamespace.translations["fr"] = {"test":"Test2"};
+EOF
+    end
+  end
+end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -5,7 +5,8 @@ describe I18n::JS::Segment do
   let(:file)        { "tmp/i18n-js/segment.js" }
   let(:translations){ { "en" => { "test" => "Test" }, "fr" => { "test" => "Test2" } } }
   let(:namespace)   { "MyNamespace" }
-  let(:options)     { {namespace: namespace} }
+  let(:pretty_print){ nil }
+  let(:options)     { {namespace: namespace, pretty_print: pretty_print} }
   subject { I18n::JS::Segment.new(file, translations, options) }
 
   describe ".new" do
@@ -35,6 +36,20 @@ describe I18n::JS::Segment do
 
       it "should default namespace to `I18n`" do
         subject.namespace.should eql("I18n")
+      end
+    end
+
+    context "when pretty_print is nil" do
+      it "should set pretty_print to false" do
+        subject.pretty_print.should be false
+      end
+    end
+
+    context "when pretty_print is truthy" do
+      let(:pretty_print){ 1 }
+
+      it "should set pretty_print to true" do
+        subject.pretty_print.should be true
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ module Helpers
   end
 
   def file_should_exist(name)
-    file_path = File.join(I18n::JS::DEFAULT_EXPORT_DIR_PATH, name)
+    file_path = File.join(temp_path, name)
     File.should be_file(file_path)
   end
 

--- a/spec/sprockets_spec.rb
+++ b/spec/sprockets_spec.rb
@@ -1,0 +1,42 @@
+
+describe I18n::JS::Dependencies, ".sprockets_supports_register_preprocessor?" do
+
+  subject { described_class.sprockets_supports_register_preprocessor? }
+
+  context 'when Sprockets is available to register preprocessors' do
+    let!(:sprockets_double) do
+      class_double('Sprockets').as_stubbed_const(register_processor: true).tap do |double|
+        allow(double).to receive(:respond_to?).with(:register_preprocessor).and_return(true)
+      end
+    end
+
+    it { is_expected.to be_truthy }
+    it 'calls respond_to? with register_preprocessor on Sprockets' do
+      expect(sprockets_double).to receive(:respond_to?).with(:register_preprocessor).and_return(true)
+      subject
+    end
+  end
+
+  context 'when Sprockets is NOT available to register preprocessors' do
+    let!(:sprockets_double) do
+      class_double('Sprockets').as_stubbed_const(register_processor: true).tap do |double|
+        allow(double).to receive(:respond_to?).with(:register_preprocessor).and_return(false)
+      end
+    end
+
+    it { is_expected.to be_falsy }
+    it 'calls respond_to? with register_preprocessor on Sprockets' do
+      expect(sprockets_double).to receive(:respond_to?).with(:register_preprocessor).and_return(false)
+      subject
+    end
+  end
+
+  context 'when Sprockets is missing' do
+    before do
+      hide_const('Sprockets')
+      expect { Sprockets }.to raise_error(NameError)
+    end
+
+    it { is_expected.to be_falsy }
+  end
+end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,39 @@
+describe I18n::JS::Utils do
+
+  describe ".strip_keys_with_nil_values" do
+    subject { described_class.strip_keys_with_nil_values(input_hash) }
+
+    context 'when input_hash does NOT contain nil value' do
+      let(:input_hash) { {a: 1, b: { c: 2 }} }
+      let(:expected_hash) { input_hash }
+
+      it 'returns the original input' do
+        is_expected.to eq expected_hash
+      end
+    end
+    context 'when input_hash does contain nil value' do
+      let(:input_hash) { {a: 1, b: { c: 2, d: nil }, e: { f: nil }} }
+      let(:expected_hash) { {a: 1, b: { c: 2 }, e: {}} }
+
+      it 'returns the original input with nil values removed' do
+        is_expected.to eq expected_hash
+      end
+    end
+  end
+
+  context "hash merging" do
+    it "performs a deep merge" do
+      target = {:a => {:b => 1}}
+      result = described_class.deep_merge(target, {:a => {:c => 2}})
+
+      result[:a].should eql({:b => 1, :c => 2})
+    end
+
+    it "performs a banged deep merge" do
+      target = {:a => {:b => 1}}
+      described_class.deep_merge!(target, {:a => {:c => 2}})
+
+      target[:a].should eql({:b => 1, :c => 2})
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the following features:
- Add `:namespace` option to config (per segment) which sets the Javascript namespace in the translations output file in order to avoid namespace conflicts
- Add `:pretty_print` option to config (per segment) which writes the output file with linebreaks and indentation
- Add `:export_i18n_js` to config (global) which functions the same as `I18n::JS.export_i18n_js_dir_path`

In addition, I have refactored the following:
- Extract "Segment" class which handles writing of translation JSON files, and allows options to be set per-segment. Includes specs.
- Move some specs to new `sprockets_spec.rb` and `utils_spec.rb` files to reduce bloat
- Minor change of `I18n::JS.export_i18n_js_dir_path` so that any non-`String` is interpreted as "do not export". This should not break existing implementations, and also the README has previously said the only way you can set path is via a `String` variable.