### PR TITLE
Config options: Namespace and PrettyPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,36 @@ You must disable this feature by setting the option to `false`.
 To find more examples on how to use the configuration file please refer to the tests.
 
 
+#### Namespace
+
+Setting the `namespace` option will change the namespace of the output Javascript file to something other than `I18n`.
+This can be useful in no-conflict scenarios. Example:
+
+```yaml
+translations:
+- file: "public/javascripts/i18n/translations.js"
+  namespace: "MyNamespace"
+```
+
+will create:
+
+```
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = { ... }
+```
+
+
+#### Pretty Print
+
+Set the `pretty_print` option if you would like whitespace and indentation in your output file (default: false)
+
+```yaml
+translations:
+- file: "public/javascripts/i18n/translations.js"
+  pretty_print: true
+```
+
+
 #### Vanilla JavaScript
 
 Just add the `i18n.js` file to your page. You'll have to build the translations object

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ translations:
 
 To find more examples on how to use the configuration file please refer to the tests.
 
-##### Fallbacks
+#### Fallbacks
 
 If you specify the `fallbacks` option, you will be able to fill missing translations with those inside fallback locale(s).  
 Default value is `true`.
@@ -186,6 +186,7 @@ To find more examples on how to use the configuration file please refer to the t
 
 Just add the `i18n.js` file to your page. You'll have to build the translations object
 by hand or using your favorite programming language. More info below.
+
 
 #### Via NPM with webpack and CommonJS
 

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -3,11 +3,13 @@ module I18n
 
     # Class which enscapulates a translations hash and outputs a single JSON translation file
     class Segment
-      attr_accessor :file, :translations
+      attr_accessor :file, :translations, :namespace, :pretty_print
 
       def initialize(file, translations, options = {})
         @file         = file
         @translations = translations
+        @namespace    = options[:namespace] || 'I18n'
+        @pretty_print = !!options[:pretty_print]
       end
 
       # Saves JSON file containing translations
@@ -15,9 +17,9 @@ module I18n
         FileUtils.mkdir_p File.dirname(self.file)
 
         File.open(self.file, "w+") do |f|
-          f << %(I18n.translations || (I18n.translations = {});\n)
+          f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
           self.translations.each do |locale, translations|
-            f << %(I18n.translations["#{locale}"] = #{print_json(translations)};\n);
+            f << %(#{self.namespace}.translations["#{locale}"] = #{print_json(translations)};\n);
           end
         end
       end
@@ -26,7 +28,11 @@ module I18n
 
       # Outputs pretty or ugly JSON depending on :pretty_print option
       def print_json(translations)
-        translations.to_json
+        if pretty_print
+          JSON.pretty_generate(translations)
+        else
+          translations.to_json
+        end
       end
     end
   end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -1,0 +1,33 @@
+module I18n
+  module JS
+
+    # Class which enscapulates a translations hash and outputs a single JSON translation file
+    class Segment
+      attr_accessor :file, :translations
+
+      def initialize(file, translations, options = {})
+        @file         = file
+        @translations = translations
+      end
+
+      # Saves JSON file containing translations
+      def save!
+        FileUtils.mkdir_p File.dirname(self.file)
+
+        File.open(self.file, "w+") do |f|
+          f << %(I18n.translations || (I18n.translations = {});\n)
+          self.translations.each do |locale, translations|
+            f << %(I18n.translations["#{locale}"] = #{print_json(translations)};\n);
+          end
+        end
+      end
+
+      protected
+
+      # Outputs pretty or ugly JSON depending on :pretty_print option
+      def print_json(translations)
+        translations.to_json
+      end
+    end
+  end
+end

--- a/spec/fixtures/js_file_with_namespace_and_pretty_print.yml
+++ b/spec/fixtures/js_file_with_namespace_and_pretty_print.yml
@@ -1,0 +1,5 @@
+translations:
+  - file: "tmp/i18n-js/%{locale}.js"
+    only: '*'
+    namespace: "Foo"
+    pretty_print: true

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -188,6 +188,38 @@ describe I18n::JS do
     end
   end
 
+  context "namespace and pretty_print options" do
+
+    before do
+      stub_const('I18n::JS::DEFAULT_EXPORT_DIR_PATH', temp_path)
+      set_config "js_file_with_namespace_and_pretty_print.yml"
+    end
+
+    it "exports with defined locale as fallback when enabled" do
+      I18n::JS.export
+      file_should_exist "en.js"
+      output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "en.js"))
+      expect(output).to match(/^#{
+<<EOS
+Foo.translations || (Foo.translations = {});
+Foo.translations["en"] = {
+  "number": {
+      "format": {
+EOS
+}.+#{
+<<EOS
+    "edit": {
+      "title": "Edit"
+    }
+  },
+  "foo": "Foo",
+  "fallback_test": "Success"
+};
+EOS
+}$/)
+    end
+  end
+
   context "I18n.available_locales" do
     context "when I18n.available_locales is not set" do
       it "should allow all locales" do

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe I18n::JS::Segment do
+
+  let(:file)        { "tmp/i18n-js/segment.js" }
+  let(:translations){ { "en" => { "test" => "Test" }, "fr" => { "test" => "Test2" } } }
+  let(:options)     { {} }
+  subject { I18n::JS::Segment.new(file, translations, options) }
+
+  describe ".new" do
+
+    it "should persist the file path variable" do
+      subject.file.should eql("tmp/i18n-js/segment.js")
+    end
+
+    it "should persist the translations variable" do
+      subject.translations.should eql(translations)
+    end
+  end
+
+  describe "#save!" do
+    before { allow(I18n::JS).to receive(:export_i18n_js_dir_path).and_return(temp_path) }
+    before { subject.save! }
+
+    it "should write the file" do
+      file_should_exist "segment.js"
+
+      File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
+I18n.translations || (I18n.translations = {});
+I18n.translations["en"] = {"test":"Test"};
+I18n.translations["fr"] = {"test":"Test2"};
+EOF
+    end
+  end
+end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -4,7 +4,9 @@ describe I18n::JS::Segment do
 
   let(:file)        { "tmp/i18n-js/segment.js" }
   let(:translations){ { "en" => { "test" => "Test" }, "fr" => { "test" => "Test2" } } }
-  let(:options)     { {} }
+  let(:namespace)   { "MyNamespace" }
+  let(:pretty_print){ nil }
+  let(:options)     { {namespace: namespace, pretty_print: pretty_print} }
   subject { I18n::JS::Segment.new(file, translations, options) }
 
   describe ".new" do
@@ -16,6 +18,40 @@ describe I18n::JS::Segment do
     it "should persist the translations variable" do
       subject.translations.should eql(translations)
     end
+
+    it "should persist the namespace variable" do
+      subject.namespace.should eql("MyNamespace")
+    end
+
+    context "when namespace is nil" do
+      let(:namespace){ nil }
+
+      it "should default namespace to `I18n`" do
+        subject.namespace.should eql("I18n")
+      end
+    end
+
+    context "when namespace is not set" do
+      subject { I18n::JS::Segment.new(file, translations) }
+
+      it "should default namespace to `I18n`" do
+        subject.namespace.should eql("I18n")
+      end
+    end
+
+    context "when pretty_print is nil" do
+      it "should set pretty_print to false" do
+        subject.pretty_print.should be false
+      end
+    end
+
+    context "when pretty_print is truthy" do
+      let(:pretty_print){ 1 }
+
+      it "should set pretty_print to true" do
+        subject.pretty_print.should be true
+      end
+    end
   end
 
   describe "#save!" do
@@ -26,9 +62,9 @@ describe I18n::JS::Segment do
       file_should_exist "segment.js"
 
       File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
-I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = {"test":"Test"};
-I18n.translations["fr"] = {"test":"Test2"};
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = {"test":"Test"};
+MyNamespace.translations["fr"] = {"test":"Test2"};
 EOF
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ module Helpers
   end
 
   def file_should_exist(name)
-    file_path = File.join(I18n::JS::DEFAULT_EXPORT_DIR_PATH, name)
+    file_path = File.join(temp_path, name)
     File.should be_file(file_path)
   end
 


### PR DESCRIPTION
This commit adds the following features:
- Add `:namespace` option to config (per segment) which sets the Javascript namespace in the translations output file in order to avoid namespace conflicts
- Add `:pretty_print` option to config (per segment) which writes the output file with linebreaks and indentation

Please merge #299 first