### PR TITLE
reworked 'guess' missing behaviour patch.. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## Unreleased
 
+- You can now set `I18n.missingBehavior='guess'` to have the scope string output as text instead of of the
+  "[missing `scope`]" message when no translation is available.
+- Combined that with `I18n.missingTranslationPrefix='SOMETHING'` and you can
+  still identify those missing strings.
+
 ### enhancements
 
 - Force currency number sign to be at first place using `sign_first` option, default to `true`

--- a/README.md
+++ b/README.md
@@ -329,6 +329,33 @@ are three different ways of doing it so:
     I18n.locales.no = "nb";
     I18n.locales.no = function(locale){ return ["nb"]; };
 
+By default a missing translation will be displayed as
+
+    [missing "name of scope" translation]
+
+While you are developing or if you do not want to provide a translation
+in the default language you can set
+
+    I18n.missingBehaviour='guess';
+
+this will take the last section of your scope and guess the intended value.
+Camel case becomes lower cased text and underscores are replaced with space
+
+    questionnaire.whatIsYourFavorite_ChristmasPresent
+
+becomes "what is your favorite Christmas present"
+
+In order to still detect untranslated strings, you can
+i18n.missingTranslationPrefix to something like:
+
+  I18n.missingTranslationPrefix = 'EE: '
+
+And result will be:
+
+    "EE: what is your favorite Christmas present"
+
+This will help you doing automated tests against your localisation assets.
+
 Pluralization is possible as well and by default provides English rules:
 
     I18n.t("inbox.counting", {count: 10}); // You have 10 messages

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -78,12 +78,27 @@
 
   // Other default options
   var DEFAULT_OPTIONS = {
-    defaultLocale: "en",
-    locale: "en",
-    defaultSeparator: ".",
-    placeholder: /(?:\{\{|%\{)(.*?)(?:\}\}?)/gm,
-    fallbacks: false,
-    translations: {}
+    // Set default locale. This locale will be used when fallback is enabled and
+    // the translation doesn't exist in a particular locale.
+      defaultLocale: "en"
+    // Set the current locale to `en`.
+    , locale: "en"
+    // Set the translation key separator.
+    , defaultSeparator: "."
+    // Set the placeholder format. Accepts `{placeholder}}` and `%{placeholder}`.}
+    , placeholder: /(?:\{\{|%\{)(.*?)(?:\}\}?)/gm
+    // Set if engine should fallback to the default locale when a translation
+    // is missing.
+    , fallbacks: false
+    // Set the default translation object.
+    , translations: {}
+    // Set missing translation behavior. 'message' will display a message
+    // that the translation is missing, 'guess' will try to guess the string
+    , missingBehaviour: 'message'
+    // if you use missingBehaviour with 'message', but want to know that the
+    // string is actually missing for testing purposes, you can prefix the
+    // guessed string by setting the value here. By default, no prefix!
+    , missingTranslationPrefix: ''
   };
 
   I18n.reset = function() {
@@ -106,6 +121,13 @@
 
     // Set the default translation object.
     this.translations = DEFAULT_OPTIONS.translations;
+
+    // Set the default missing behaviour
+    this.missingBehaviour = DEFAULT_OPTIONS.missingBehaviour;
+
+    // Set the default missing string prefix for guess behaviour
+    this.missingTranslationPrefix = DEFAULT_OPTIONS.missingTranslationPrefix;
+
   };
 
   // Much like `reset`, but only assign options if not already assigned
@@ -462,6 +484,16 @@
 
   // Return a missing translation message for the given parameters.
   I18n.missingTranslation = function(scope, options) {
+    //guess intended string
+    if(this.missingBehaviour == 'guess'){
+      //get only the last portion of the scope
+      var s = scope.split('.').slice(-1)[0];
+      //replace underscore with space && camelcase with space and lowercase letter
+      return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
+          s.replace('_',' ').replace(/([a-z])([A-Z])/g,
+          function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
+    }
+
     var fullScope           = this.getFullScope(scope, options);
     var fullScopeWithLocale = [this.currentLocale(), fullScope].join(this.defaultSeparator);
 

--- a/spec/js/defaults.spec.js
+++ b/spec/js/defaults.spec.js
@@ -20,4 +20,12 @@ describe("Defaults", function(){
   it("sets fallback", function(){
     expect(I18n.fallbacks).toEqual(false);
   });
+
+  it("set empty translation prefix", function(){
+    expect(I18n.missingTranslationPrefix).toEqual('');
+  });
+
+  it("sets default missingBehaviour", function(){
+    expect(I18n.missingBehaviour).toEqual('message');
+  });
 });

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -24,6 +24,21 @@ describe("Translate", function(){
     expect(actual).toEqual(expected);
   });
 
+  it("returns guessed translation if missingBehaviour is set to guess", function(){
+    I18n.missingBehaviour = 'guess'
+    actual = I18n.t("invalid.thisIsAutomaticallyGeneratedTranslation");
+    expected = 'this is automatically generated translation';
+    expect(actual).toEqual(expected);
+  });
+
+  it("returns guessed translation with prefix if missingBehaviour is set to guess and prefix is also provided", function(){
+    I18n.missingBehaviour = 'guess'
+    I18n.missingTranslationPrefix = 'EE: '
+    actual = I18n.t("invalid.thisIsAutomaticallyGeneratedTranslation");
+    expected = 'EE: this is automatically generated translation';
+    expect(actual).toEqual(expected);
+  });
+
   it("returns missing message translation for valid scope with scope", function(){
     actual = I18n.t("monster", {scope: "greetings"});
     expected = '[missing "en.greetings.monster" translation]';


### PR DESCRIPTION
Added option missingBehaviour, which avoids to have to create strings when developing or simple strings that do not need a declaration in the default language.
Combine that with missingTranslationPrefix and you can still identify which strings are translated and which are guessed.

This commit is based on pr#220 with some small changes added.. 