### PR TITLE
2.X - Updated url used to retrieve js library from Github.

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -111,7 +111,7 @@ module SimplesIdeias
     # Retrieve an updated JavaScript library from Github.
     def update!
       require "open-uri"
-      contents = open("https://raw.github.com/fnando/i18n-js/master/vendor/assets/javascripts/i18n.js").read
+      contents = open("https://raw.githubusercontent.com/fnando/i18n-js/2.x/vendor/assets/javascripts/i18n.js").read
       File.open(javascript_file, "w+") {|f| f << contents}
     end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -170,7 +170,7 @@ describe SimplesIdeias::I18n do
   end
 
   it "updates the javascript library" do
-    FakeWeb.register_uri(:get, "https://raw.github.com/fnando/i18n-js/master/vendor/assets/javascripts/i18n.js", :body => "UPDATED")
+    FakeWeb.register_uri(:get, "https://raw.githubusercontent.com/fnando/i18n-js/2.x/vendor/assets/javascripts/i18n.js", :body => "UPDATED")
 
     SimplesIdeias::I18n.setup!
     SimplesIdeias::I18n.update!


### PR DESCRIPTION
In the old 2.X branch the js file was being pulled from the wrong location; I fixed it.