### PR TITLE
Fix for usage with a beta or rc version of rails

### DIFF
--- a/lib/i18n/js/dependencies.rb
+++ b/lib/i18n/js/dependencies.rb
@@ -53,7 +53,7 @@ module I18n
 
         def safe_gem_check(*args)
           if Gem::Specification.respond_to?(:find_by_name)
-            Gem::Specification.find_by_name(*args)
+            Gem::Specification.find_all_by_name(*args)
           elsif Gem.respond_to?(:available?)
             Gem.available?(*args)
           end


### PR DESCRIPTION
For beta/rc versions of Rails, `find_by_name` does not return the rails gem. By using the less strict `find_all_by_name` method, this allows using `i18n-js` with versions of rails like `4.2.1.rc1`.