### PR TITLE
Unify/simplify the behavior of per-locale and non-per-locale files by moving per-locale generation to Segment class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 
 ## Unreleased
 
-### enhancements
-
-### bug fixes
-
-
-## 3.0.0.rc9
-
 ### breaking changes
 
 - [Ruby] In `config/i18n-js.yml`, if you are using `%{locale}` in your filename and are referencing specific translations keys, please add `*.` to the beginning of those keys. ([#320](https://github.com/fnando/i18n-js/pull/320))
+
+### enhancements
+
+- [Ruby] Make handling of per-locale and not-per-locale exporting to be more consistent ([#320](https://github.com/fnando/i18n-js/pull/320))
+
+### bug fixes
+
+- [Ruby] Fix fallback logic to work with not-per-locale files ([#320](https://github.com/fnando/i18n-js/pull/320))
+
+
+## 3.0.0.rc9
 
 ### enhancements
 
@@ -25,8 +29,6 @@
   Combined that with `I18n.missingTranslationPrefix='SOMETHING'` and you can
   still identify those missing strings.
   ([#304](https://github.com/fnando/i18n-js/pull/304))
-- [Ruby] Make handling of per-locale and not-per-locale exporting to be more consistent ([#320](https://github.com/fnando/i18n-js/pull/320))
-- [Ruby] Fix fallback logic to work with not-per-locale files ([#320](https://github.com/fnando/i18n-js/pull/320))
 
 ### bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## 3.0.0.rc9
 
+### breaking changes
+
+- [Ruby] In `config/i18n-js.yml`, if you are using `%{locale}` in your filename and are referencing specific translations keys, please add `*.` to the beginning of those keys. ([#320](https://github.com/fnando/i18n-js/pull/320))
+
 ### enhancements
 
 - [JS] Force currency number sign to be at first place using `sign_first` option, default to `true`
@@ -21,6 +25,8 @@
   Combined that with `I18n.missingTranslationPrefix='SOMETHING'` and you can
   still identify those missing strings.
   ([#304](https://github.com/fnando/i18n-js/pull/304))
+- [Ruby] Make handling of per-locale and not-per-locale exporting to be more consistent ([#320](https://github.com/fnando/i18n-js/pull/320))
+- [Ruby] Fix fallback logic to work with not-per-locale files ([#320](https://github.com/fnando/i18n-js/pull/320))
 
 ### bug fixes
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ translations:
 - file: "public/javascripts/i18n/%{locale}.js"
   only: '*'
 - file: "public/javascripts/frontend/i18n/%{locale}.js"
-  only: ['frontend', 'users']
+  only: ['*.frontend', '*.users.*']
 ```
 
 You can also include ERB in your config file.

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -107,9 +107,9 @@ module I18n
 
       [scopes].flatten.each do |scope|
         translations_without_exceptions = exclude(translations, exceptions)
-        filtered_translations = filter(translations_without_exceptions, scope)
+        filtered_translations = filter(translations_without_exceptions, scope) || {}
 
-        Utils.deep_merge! result, filtered_translations || {}
+        Utils.deep_merge!(result, filtered_translations)
       end
 
       result

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -34,17 +34,6 @@ module I18n
       translation_segments.each(&:save!)
     end
 
-    def self.segments_per_locale(pattern, scope, exceptions, options)
-      I18n.available_locales.each_with_object([]) do |locale, segments|
-        scope = [scope] unless scope.respond_to?(:each)
-        result = scoped_translations(scope.collect{|s| "#{locale}.#{s}"}, exceptions)
-        merge_with_fallbacks!(result, locale, scope, exceptions) if use_fallbacks?
-
-        next if result.empty?
-        segments << Segment.new(::I18n.interpolate(pattern, {:locale => locale}), result, options)
-      end
-    end
-
     def self.segment_for_scope(scope, exceptions)
       if scope == "*"
         exclude(translations, exceptions)
@@ -61,14 +50,23 @@ module I18n
 
         segment_options = options.slice(:namespace, :pretty_print)
 
-        if file =~ ::I18n::INTERPOLATION_PATTERN
-          segments += segments_per_locale(file, only, exceptions, segment_options)
-        else
-          result = segment_for_scope(only, exceptions)
-          segments << Segment.new(file, result, segment_options) unless result.empty?
-        end
+        result = segment_for_scope(only, exceptions)
+
+        merge_with_fallbacks!(result) if fallbacks
+
+        segments << Segment.new(file, result, segment_options) unless result.empty?
 
         segments
+      end
+    end
+
+    # deep_merge! given result with result for fallback locale
+    def self.merge_with_fallbacks!(result)
+      I18n.available_locales.each do |locale|
+        fallback_locales = FallbackLocales.new(fallbacks, locale)
+        fallback_locales.each do |fallback_locale|
+          result[locale] = Utils.deep_merge(result[fallback_locale], result[locale] || {})
+        end
       end
     end
 
@@ -111,7 +109,7 @@ module I18n
         translations_without_exceptions = exclude(translations, exceptions)
         filtered_translations = filter(translations_without_exceptions, scope)
 
-        Utils.deep_merge! result, filtered_translations
+        Utils.deep_merge! result, filtered_translations || {}
       end
 
       result
@@ -163,17 +161,6 @@ module I18n
       config.fetch(:fallbacks) do
         # default value
         true
-      end
-    end
-
-    # deep_merge! given result with result for fallback locale
-    def self.merge_with_fallbacks!(result, locale, scope, exceptions)
-      result[locale] ||= {}
-      fallback_locales = FallbackLocales.new(fallbacks, locale)
-
-      fallback_locales.each do |fallback_locale|
-        fallback_result = scoped_translations(scope.collect{|s| "#{fallback_locale}.#{s}"}, exceptions) # NOTE: Duplicated code here
-        result[locale] = Utils.deep_merge(fallback_result[fallback_locale], result[locale])
       end
     end
 

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -16,16 +16,18 @@ module I18n
 
       # Saves JSON file containing translations
       def save!
-        if file =~ LOCALE_INTERPOLATOR
+        if self.file =~ LOCALE_INTERPOLATOR
           I18n.available_locales.each do |locale|
             write_file(file_for_locale(locale), self.translations.slice(locale))
           end
         else
-          write_file(self.file, self.translations)
+          write_file
         end
       end
 
-      def write_file(_file, _translations)
+      protected
+
+      def write_file(_file = self.file, _translations = self.translations)
         FileUtils.mkdir_p File.dirname(_file)
         File.open(_file, "w+") do |f|
           f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
@@ -34,8 +36,6 @@ module I18n
           end
         end
       end
-
-      protected
 
       # Outputs pretty or ugly JSON depending on :pretty_print option
       def print_json(translations)

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -5,6 +5,8 @@ module I18n
     class Segment
       attr_accessor :file, :translations, :namespace, :pretty_print
 
+      LOCALE_INTERPOLATOR = /%\{locale\}/
+
       def initialize(file, translations, options = {})
         @file         = file
         @translations = translations
@@ -14,12 +16,21 @@ module I18n
 
       # Saves JSON file containing translations
       def save!
-        FileUtils.mkdir_p File.dirname(self.file)
+        if file =~ LOCALE_INTERPOLATOR
+          I18n.available_locales.each do |locale|
+            write_file(file_for_locale(locale), self.translations.slice(locale))
+          end
+        else
+          write_file(self.file, self.translations)
+        end
+      end
 
-        File.open(self.file, "w+") do |f|
+      def write_file(_file, _translations)
+        FileUtils.mkdir_p File.dirname(_file)
+        File.open(_file, "w+") do |f|
           f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
-          self.translations.each do |locale, translations|
-            f << %(#{self.namespace}.translations["#{locale}"] = #{print_json(translations)};\n);
+          _translations.each do |locale, translations_for_locale|
+            f << %(#{self.namespace}.translations["#{locale}"] = #{print_json(translations_for_locale)};\n);
           end
         end
       end
@@ -33,6 +44,11 @@ module I18n
         else
           translations.to_json
         end
+      end
+
+      # interpolates filename
+      def file_for_locale(locale)
+        self.file.gsub(LOCALE_INTERPOLATOR, locale.to_s)
       end
     end
   end

--- a/spec/fixtures/custom_path.yml
+++ b/spec/fixtures/custom_path.yml
@@ -1,4 +1,5 @@
-# Find more details about this configuration file at http://github.com/fnando/i18n-js
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/all.js"
     only: "*"

--- a/spec/fixtures/default.yml
+++ b/spec/fixtures/default.yml
@@ -1,4 +1,5 @@
-# Find more details about this configuration file at http://github.com/fnando/i18n-js
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/translations.js"
     only: "*"

--- a/spec/fixtures/erb.yml
+++ b/spec/fixtures/erb.yml
@@ -1,4 +1,5 @@
-# Find more details about this configuration file at http://github.com/fnando/i18n-js
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/translations.js"
     only: '<%= "*." + "date." + "formats" %>'

--- a/spec/fixtures/except_condition.yml
+++ b/spec/fixtures/except_condition.yml
@@ -1,3 +1,5 @@
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/trimmed.js"
     except:

--- a/spec/fixtures/js_export_dir_custom.yml
+++ b/spec/fixtures/js_export_dir_custom.yml
@@ -1,3 +1,4 @@
+fallbacks: false
 
 export_i18n_js: 'tmp/i18n-js/foo'
 

--- a/spec/fixtures/js_export_dir_none.yml
+++ b/spec/fixtures/js_export_dir_none.yml
@@ -1,4 +1,4 @@
-
+fallbacks: false
 export_i18n_js: false
 
 translations:

--- a/spec/fixtures/js_file_per_locale.yml
+++ b/spec/fixtures/js_file_per_locale.yml
@@ -1,3 +1,7 @@
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/%{locale}.js"
-    only: '*'
+    only:
+      - '*.date.*'
+      - '*.admin.*'

--- a/spec/fixtures/js_file_with_namespace_and_pretty_print.yml
+++ b/spec/fixtures/js_file_with_namespace_and_pretty_print.yml
@@ -1,3 +1,5 @@
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/%{locale}.js"
     only: '*'

--- a/spec/fixtures/multiple_conditions.yml
+++ b/spec/fixtures/multiple_conditions.yml
@@ -1,3 +1,5 @@
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/bitsnpieces.js"
     only:

--- a/spec/fixtures/multiple_conditions_per_locale.yml
+++ b/spec/fixtures/multiple_conditions_per_locale.yml
@@ -1,5 +1,7 @@
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/bits.%{locale}.js"
     only:
-      - "date.formats"
-      - "number.currency"
+      - "*.date.formats.*"
+      - "*.number.currency.*"

--- a/spec/fixtures/multiple_files.yml
+++ b/spec/fixtures/multiple_files.yml
@@ -1,4 +1,5 @@
-# Find more details about this configuration file at http://github.com/fnando/i18n-js
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/all.js"
     only: "*"

--- a/spec/fixtures/no_scope.yml
+++ b/spec/fixtures/no_scope.yml
@@ -1,3 +1,4 @@
-# Find more details about this configuration file at http://github.com/fnando/i18n-js
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/no_scope.js"

--- a/spec/fixtures/simple_scope.yml
+++ b/spec/fixtures/simple_scope.yml
@@ -1,4 +1,5 @@
-# Find more details about this configuration file at http://github.com/fnando/i18n-js
+fallbacks: false
+
 translations:
   - file: "tmp/i18n-js/simple_scope.js"
     only: "*.date.formats"

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -283,7 +283,6 @@ EOS
   end
 
   context "I18n.available_locales" do
-    # before { allow(I18n::JS).to receive(:fallbacks).and_return(false) }
 
     context "when I18n.available_locales is not set" do
       it "should allow all locales" do

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe I18n::JS::Segment do
 
   let(:file)        { "tmp/i18n-js/segment.js" }
-  let(:translations){ { "en" => { "test" => "Test" }, "fr" => { "test" => "Test2" } } }
+  let(:translations){ { en: { "test" => "Test" }, fr: { "test" => "Test2" } } }
   let(:namespace)   { "MyNamespace" }
   let(:pretty_print){ nil }
   let(:options)     { {namespace: namespace, pretty_print: pretty_print} }
@@ -58,14 +58,35 @@ describe I18n::JS::Segment do
     before { allow(I18n::JS).to receive(:export_i18n_js_dir_path).and_return(temp_path) }
     before { subject.save! }
 
-    it "should write the file" do
-      file_should_exist "segment.js"
+    context "when file does not include %{locale}" do
+      it "should write the file" do
+        file_should_exist "segment.js"
 
-      File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
+        File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
 MyNamespace.translations["en"] = {"test":"Test"};
 MyNamespace.translations["fr"] = {"test":"Test2"};
-EOF
+        EOF
+      end
+    end
+
+    context "when file includes %{locale}" do
+      let(:file){ "tmp/i18n-js/%{locale}.js" }
+
+      it "should write files" do
+        file_should_exist "en.js"
+        file_should_exist "fr.js"
+
+        File.open(File.join(temp_path, "en.js")){|f| f.read}.should eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = {"test":"Test"};
+        EOF
+
+        File.open(File.join(temp_path, "fr.js")){|f| f.read}.should eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["fr"] = {"test":"Test2"};
+        EOF
+      end
     end
   end
 end


### PR DESCRIPTION
This PR unifies/simplifies the behavior of per-locale and non-per-locale files.

Specifically, splitting files per-locale generation is done in the `Segment` class `.save!` method, which is the final step before writing the file. (Previously, "per-locale" and "non-per-locale" files followed very different logic paths which diverged early in the processing chain.)

One positive effect of this change is that the "fallbacks" feature now works for both per-locale and non-per-locale files.

**Important:** There are two breaking changes in this PR, hence I recommend a minor version bump.

1. Per-locale files should now have `only`/`exclude` scopes which begin with '*', which is the same as non-per-locale files.

2. Since this PR fixes the issue that fallbacks were ignored for non-per-locale files, users may see some behavior change. for this. This is unavoidable as it's essentially a bug that this wasn't done before.

Lastly, please note that I had to add `fallbacks: false` to many of the test fixtures to ensure behavior consistency.
