### PR TITLE
JS file: set count to 1 by default

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -331,7 +331,7 @@
   //
   I18n.prepareOptions = function() {
     var args = slice.call(arguments)
-      , options = {}
+      , options = {count: 1}
       , subject
     ;
 
@@ -344,10 +344,6 @@
 
       for (var attr in subject) {
         if (!subject.hasOwnProperty(attr)) {
-          continue;
-        }
-
-        if (this.isSet(options[attr])) {
           continue;
         }
 


### PR DESCRIPTION
I think it's useful to set count to 1 by default. The user can override it, but it saves the user from having to set count in lots of places when you use a lot of pluralizations.

Currently if you have a pluralized key and you DON'T set count 1, you see `[Object object]`. There's also no harm setting count: 1 on a non-pluralized key.
