### PR TITLE
Absolute exception specifiers with wildcard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### breaking changes
 
 - [Ruby] In `config/i18n-js.yml`, if you are using `%{locale}` in your filename and are referencing specific translations keys, please add `*.` to the beginning of those keys. ([#320](https://github.com/fnando/i18n-js/pull/320))
+- [Ruby] The `:except` option to exclude certain phrases now (only) accepts the same patterns the `:only` option accepts
 
 ### enhancements
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ keys listed in `except` configuration param:
 
 ```yaml
 translations:
-  - except: ['active_admin', 'ransack']
+  - except: ['*.active_admin', '*.ransack', '*.activerecord.errors']
 ```
 
 

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -124,7 +124,7 @@ module I18n
       exceptions.inject(translations) do |memo, exception|
         exception_scopes = exception.to_s.split(".")
         Utils.deep_reject(memo) do |key, value, scopes|
-          key.to_s == exception.to_s || Utils.scopes_match?(scopes, exception_scopes)
+          Utils.scopes_match?(scopes, exception_scopes)
         end
       end
     end

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -122,8 +122,9 @@ module I18n
       return translations if exceptions.empty?
 
       exceptions.inject(translations) do |memo, exception|
-        Utils.deep_reject(memo) do |key, value|
-          key.to_s == exception.to_s
+        exception_scopes = exception.to_s.split(".")
+        Utils.deep_reject(memo) do |key, value, scopes|
+          key.to_s == exception.to_s or Utils.scopes_match?(scopes, exception_scopes)
         end
       end
     end

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -124,7 +124,7 @@ module I18n
       exceptions.inject(translations) do |memo, exception|
         exception_scopes = exception.to_s.split(".")
         Utils.deep_reject(memo) do |key, value, scopes|
-          key.to_s == exception.to_s or Utils.scopes_match?(scopes, exception_scopes)
+          key.to_s == exception.to_s || Utils.scopes_match?(scopes, exception_scopes)
         end
       end
     end

--- a/lib/i18n/js/utils.rb
+++ b/lib/i18n/js/utils.rb
@@ -33,7 +33,7 @@ module I18n
       def self.scopes_match?(scopes1, scopes2)
         if scopes1.length == scopes2.length
           [scopes1, scopes2].transpose.all? do |scope1, scope2|
-            scope1.to_s == '*' or scope2.to_s == '*' or scope1.to_s == scope2.to_s
+            scope1.to_s == '*' || scope2.to_s == '*' || scope1.to_s == scope2.to_s
           end
         end
       end

--- a/lib/i18n/js/utils.rb
+++ b/lib/i18n/js/utils.rb
@@ -22,10 +22,18 @@ module I18n
         target_hash.merge!(hash, &MERGER)
       end
 
-      def self.deep_reject(hash, &block)
+      def self.deep_reject(hash, scopes = [], &block)
         hash.each_with_object({}) do |(k, v), memo|
-          unless block.call(k, v)
-            memo[k] = v.kind_of?(Hash) ? deep_reject(v, &block) : v
+          unless block.call(k, v, scopes + [k.to_s])
+            memo[k] = v.kind_of?(Hash) ? deep_reject(v, scopes + [k.to_s], &block) : v
+          end
+        end
+      end
+
+      def self.scopes_match?(scopes1, scopes2)
+        if scopes1.length == scopes2.length
+          [scopes1, scopes2].transpose.all? do |scope1, scope2|
+            scope1.to_s == '*' or scope2.to_s == '*' or scope1.to_s == scope2.to_s
           end
         end
       end

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -226,6 +226,19 @@ EOS
       result[:fr][:admin][:edit].should be_empty
     end
 
+    it "does not include scopes listed in the exceptions list" do
+      result = I18n::JS.scoped_translations("*", ['de.*', '*.admin', '*.*.currency'])
+
+      result[:de].should be_empty
+
+      result[:en][:admin].should be_nil
+      result[:fr][:admin].should be_nil
+      result[:ja][:admin].should be_nil
+
+      result[:en][:number][:currency].should be_nil
+      result[:fr][:number][:currency].should be_nil
+    end
+
     it "does not include a key listed in the exceptions list and respecs the 'only' option" do
       result = I18n::JS.scoped_translations("fr.*", ['date', 'time', 'number', 'show'])
 

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -208,24 +208,6 @@ EOS
   end
 
   context "exceptions" do
-    it "does not include a key listed in the exceptions list" do
-      result = I18n::JS.scoped_translations("*", ['admin'])
-
-      result[:en][:admin].should be_nil
-      result[:fr][:admin].should be_nil
-    end
-
-    it "does not include multiple keys listed in the exceptions list" do
-      result = I18n::JS.scoped_translations("*", ['title', 'note'])
-
-      result[:en][:admin][:show].should be_empty
-      result[:en][:admin][:edit].should be_empty
-
-      result[:fr][:admin][:show].should be_empty
-      result[:fr][:admin][:show].should be_empty
-      result[:fr][:admin][:edit].should be_empty
-    end
-
     it "does not include scopes listed in the exceptions list" do
       result = I18n::JS.scoped_translations("*", ['de.*', '*.admin', '*.*.currency'])
 
@@ -239,19 +221,40 @@ EOS
       result[:fr][:number][:currency].should be_nil
     end
 
-    it "does not include a key listed in the exceptions list and respecs the 'only' option" do
-      result = I18n::JS.scoped_translations("fr.*", ['date', 'time', 'number', 'show'])
+    it "does not include scopes listed in the exceptions list and respects the 'only' option" do
+      result = I18n::JS.scoped_translations("fr.*", ['*.admin', '*.*.currency'])
 
       result[:en].should be_nil
       result[:de].should be_nil
       result[:ja].should be_nil
 
-      result[:fr][:date].should be_nil
-      result[:fr][:time].should be_nil
-      result[:fr][:number].should be_nil
-      result[:fr][:admin][:show].should be_nil
+      result[:fr][:admin].should be_nil
+      result[:fr][:number][:currency].should be_nil
 
-      result[:fr][:admin][:edit][:title].should be_a(String)
+      result[:fr][:time][:am].should be_a(String)
+    end
+
+    it "does exclude absolute scopes listed in the exceptions list" do
+      result = I18n::JS.scoped_translations("*", ['de', 'en.admin', 'fr.number.currency'])
+
+      result[:de].should be_nil
+
+      result[:en].should be_a(Hash)
+      result[:en][:admin].should be_nil
+
+      result[:fr][:number].should be_a(Hash)
+      result[:fr][:number][:currency].should be_nil
+    end
+
+    it "does not exclude non-absolute scopes listed in the exceptions list" do
+      result = I18n::JS.scoped_translations("*", ['admin', 'currency'])
+
+      result[:en][:admin].should be_a(Hash)
+      result[:fr][:admin].should be_a(Hash)
+      result[:ja][:admin].should be_a(Hash)
+
+      result[:en][:number][:currency].should be_a(Hash)
+      result[:fr][:number][:currency].should be_a(Hash)
     end
   end
 

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -76,4 +76,19 @@ describe I18n::JS::Utils do
       unsorted_hash.should eql({:z => {:b => 1, :a => 2}, :y => 3})
     end
   end
+
+  describe ".scopes_match?" do
+    it "performs a comparison of literal scopes" do
+      described_class.scopes_match?([:a, :b], [:a, :b, :c]).should_not eql true
+      described_class.scopes_match?([:a, :b, :c], [:a, :b, :c]).should eql true
+      described_class.scopes_match?([:a, :b, :c], [:a, :b, :d]).should_not eql true
+    end
+
+    it "performs a comparison of wildcard scopes" do
+      described_class.scopes_match?([:a, '*'], [:a, :b, :c]).should_not eql true
+      described_class.scopes_match?([:a, '*', :c], [:a, :b, :c]).should eql true
+      described_class.scopes_match?([:a, :b, :c], [:a, '*', :c]).should eql true
+      described_class.scopes_match?([:a, :b, :c], [:a, '*', '*']).should eql true
+    end
+  end
 end


### PR DESCRIPTION
Implemented absolute (i.e. scoped) `except` filters. The filters for `only` are always absolute (i.e. relative to the root of the translations structure), whereas `except` filters were always relative (i.e. matching local key names only).

This change adds support for absolute `except` filters, so that specific branches from the translations structure can be excluded by specifying an absolute path.

Examples:
- `except: "*.errors"` would exclude all translations in the `error` root scope for all languages, but would leave a scope like `en.devise.errors` in tact.
- `except: "*.countries.*.official"` would leave out the official country names (e.g. `en.countries.us.offical`), but would not exclude informal names (e.g. `en.countries.us.informal`).

This changes gives much more control over exclusions, preventing accidental exclusions.

To provide backwards compatibility, all unqualified `except` filters (i.e. WITHOUT periods) are considered relative and evaluated using the old logic, whereas all qualified filters (i.e. WITH period) will be evaluated as absolute. Please note that previously, `except` filters with a period were always ignored.