### PR TITLE
Allow extending of translation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### breaking changes
 
 ### enhancements
+  - [JS] Allow extending of translation files ([#354](https://github.com/fnando/i18n-js/pull/354))
 
 ### bug fixes
 

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -883,20 +883,14 @@
   I18n.p = I18n.pluralize;
 
   if ( typeof define === "function" && define.amd ) {
-    if (require.specified('i18n')) {
-      window.requirejs.undef('i18n');
-    }
-
     define(function() {
       return I18n;
     });
   }
 
-
   if ( typeof noGlobal === typeof undefined ) {
     window.I18n = I18n;
   }
-
 
   return I18n;
 }));

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -12,19 +12,16 @@
 // See tests for specific formatting like numbers and dates.
 //
 
-;(function(factory) {
-  if (typeof module !== 'undefined' && module.exports) {
-    // Node/CommonJS
-    module.exports = factory(this);
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    var global=this;
-    define('i18n', function(){ return factory(global);});
+(function( global, factory ) {
+
+  if ( typeof module === "object" && typeof module.exports === "object" ) {
+    module.exports = factory(global);
   } else {
-    // Browser globals
-    this.I18n = factory(this);
+    factory( global );
   }
-}(function(global) {
+
+// Pass this if window is not defined yet
+}(typeof window !== "undefined" ? window : this, function( global, noGlobal ) {
   "use strict";
 
   // Use previously defined object if exists in current scope
@@ -884,6 +881,22 @@
   I18n.t = I18n.translate;
   I18n.l = I18n.localize;
   I18n.p = I18n.pluralize;
+
+  if ( typeof define === "function" && define.amd ) {
+    if (require.specified('i18n')) {
+      window.requirejs.undef('i18n');
+    }
+
+    define(function() {
+      return I18n;
+    });
+  }
+
+
+  if ( typeof noGlobal === typeof undefined ) {
+    window.I18n = I18n;
+  }
+
 
   return I18n;
 }));

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -857,7 +857,28 @@
     }
 
     return scope;
-  }
+  };
+  /**
+   * Merge obj1 with obj2
+   * @param {Object} obj1 Default settings
+   * @param {Object} obj2 User obj2
+   * @returns {Object} Merged values of obj1 and obj2
+   */
+  I18n.extend = function ( obj1, obj2 ) {
+    var extended = {};
+    var prop;
+    for (prop in obj1) {
+      if (Object.prototype.hasOwnProperty.call(obj1, prop)) {
+        extended[prop] = obj1[prop];
+      }
+    }
+    for (prop in obj2) {
+      if (Object.prototype.hasOwnProperty.call(obj2, prop)) {
+        extended[prop] = obj2[prop];
+      }
+    }
+    return extended;
+  };
 
   // Set aliases, so we can save some typing.
   I18n.t = I18n.translate;

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -33,17 +33,24 @@ module I18n
           f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
           _translations.each do |locale, translations_for_locale|
             output_translations = I18n::JS.sort_translation_keys? ? Utils.deep_key_sort(translations_for_locale) : translations_for_locale
-            f << %(#{self.namespace}.translations["#{locale}"] = #{print_json(output_translations)};\n);
+            f << %(#{self.namespace}.translations["#{locale}"] = #{self.namespace}.translations["#{locale}"] || {};\n)
+            output_translations.keys.each do |key|
+              f << %(#{self.namespace}.translations["#{locale}"]["#{key}"] = #{print_json(output_translations[key])};\n);
+            end
           end
         end
       end
 
       # Outputs pretty or ugly JSON depending on :pretty_print option
       def print_json(translations)
-        if pretty_print
-          JSON.pretty_generate(translations)
-        else
-          translations.to_json
+        begin
+          if pretty_print
+            JSON.pretty_generate(translations)
+          else
+            translations.to_json
+          end
+        rescue JSON::GeneratorError
+          return translations.inspect
         end
       end
 

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -33,10 +33,7 @@ module I18n
           f << %(#{self.namespace}.translations || (#{self.namespace}.translations = {});\n)
           _translations.each do |locale, translations_for_locale|
             output_translations = I18n::JS.sort_translation_keys? ? Utils.deep_key_sort(translations_for_locale) : translations_for_locale
-            f << %(#{self.namespace}.translations["#{locale}"] = #{self.namespace}.translations["#{locale}"] || {};\n)
-            output_translations.keys.each do |key|
-              f << %(#{self.namespace}.translations["#{locale}"]["#{key}"] = #{print_json(output_translations[key])};\n);
-            end
+            f << %(#{self.namespace}.translations["#{locale}"] = I18n.extend((#{self.namespace}.translations["#{locale}"] || {}), #{print_json(output_translations)});\n)
           end
         end
       end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -40,14 +40,10 @@ module I18n
 
       # Outputs pretty or ugly JSON depending on :pretty_print option
       def print_json(translations)
-        begin
-          if pretty_print
-            JSON.pretty_generate(translations)
-          else
-            translations.to_json
-          end
-        rescue JSON::GeneratorError
-          return translations.inspect
+        if pretty_print
+          JSON.pretty_generate(translations)
+        else
+          translations.to_json
         end
       end
 

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -67,17 +67,13 @@ describe I18n::JS do
       en_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "en.js"))
       expect(en_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = I18n.translations["en"] || {};
-I18n.translations["en"]["admin"] = {"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}};
-I18n.translations["en"]["date"] = {"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]};
+I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}), {"admin":{"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}},"date":{"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]}});
 EOS
 )
       fr_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "fr.js"))
       expect(fr_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["fr"] = I18n.translations["fr"] || {};
-I18n.translations["fr"]["admin"] = {"edit":{"title":"Editer"},"show":{"note":"plus de détails","title":"Visualiser"}};
-I18n.translations["fr"]["date"] = {"abbr_day_names":["dim","lun","mar","mer","jeu","ven","sam"],"abbr_month_names":[null,"jan.","fév.","mar.","avr.","mai","juin","juil.","août","sept.","oct.","nov.","déc."],"day_names":["dimanche","lundi","mardi","mercredi","jeudi","vendredi","samedi"],"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"},"month_names":[null,"janvier","février","mars","avril","mai","juin","juillet","août","septembre","octobre","novembre","décembre"]};
+I18n.translations["fr"] = I18n.extend((I18n.translations["fr"] || {}), {"admin":{"edit":{"title":"Editer"},"show":{"note":"plus de détails","title":"Visualiser"}},"date":{"abbr_day_names":["dim","lun","mar","mer","jeu","ven","sam"],"abbr_month_names":[null,"jan.","fév.","mar.","avr.","mai","juin","juil.","août","sept.","oct.","nov.","déc."],"day_names":["dimanche","lundi","mardi","mercredi","jeudi","vendredi","samedi"],"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"},"month_names":[null,"janvier","février","mars","avril","mai","juin","juillet","août","septembre","octobre","novembre","décembre"]}});
 EOS
 )
     end
@@ -102,17 +98,13 @@ EOS
       en_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "bits.en.js"))
       expect(en_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = I18n.translations["en"] || {};
-I18n.translations["en"]["date"] = {"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"}};
-I18n.translations["en"]["number"] = {"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}}};
+I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}), {"date":{"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"}},"number":{"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}}}});
 EOS
 )
       fr_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "bits.fr.js"))
       expect(fr_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["fr"] = I18n.translations["fr"] || {};
-I18n.translations["fr"]["date"] = {"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"}};
-I18n.translations["fr"]["number"] = {"currency":{"format":{"format":"%n %u","precision":2,"unit":"€"}}};
+I18n.translations["fr"] = I18n.extend((I18n.translations["fr"] || {}), {"date":{"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"}},"number":{"currency":{"format":{"format":"%n %u","precision":2,"unit":"€"}}}});
 EOS
 )
     end
@@ -589,14 +581,7 @@ EOS
         it "exports with the keys sorted" do
           expect(subject).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = I18n.translations["en"] || {};
-I18n.translations["en"]["admin"] = {"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}};
-I18n.translations["en"]["date"] = {"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]};
-I18n.translations["en"]["fallback_test"] = "Success";
-I18n.translations["en"]["foo"] = "Foo";
-I18n.translations["en"]["null_test"] = "fallback for null";
-I18n.translations["en"]["number"] = {"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}},"format":{"delimiter":",","precision":3,"separator":"."}};
-I18n.translations["en"]["time"] = {"am":"am","formats":{"default":"%a, %d %b %Y %H:%M:%S %z","long":"%B %d, %Y %H:%M","short":"%d %b %H:%M"},"pm":"pm"};
+I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}), {"admin":{"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}},"date":{"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]},"fallback_test":"Success","foo":"Foo","null_test":"fallback for null","number":{"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}},"format":{"delimiter":",","precision":3,"separator":"."}},"time":{"am":"am","formats":{"default":"%a, %d %b %Y %H:%M:%S %z","long":"%B %d, %Y %H:%M","short":"%d %b %H:%M"},"pm":"pm"}});
 EOS
 )
         end

--- a/spec/i18n_js_spec.rb
+++ b/spec/i18n_js_spec.rb
@@ -67,13 +67,17 @@ describe I18n::JS do
       en_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "en.js"))
       expect(en_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = {"admin":{"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}},"date":{"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]}};
+I18n.translations["en"] = I18n.translations["en"] || {};
+I18n.translations["en"]["admin"] = {"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}};
+I18n.translations["en"]["date"] = {"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]};
 EOS
 )
       fr_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "fr.js"))
       expect(fr_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["fr"] = {"admin":{"edit":{"title":"Editer"},"show":{"note":"plus de détails","title":"Visualiser"}},"date":{"abbr_day_names":["dim","lun","mar","mer","jeu","ven","sam"],"abbr_month_names":[null,"jan.","fév.","mar.","avr.","mai","juin","juil.","août","sept.","oct.","nov.","déc."],"day_names":["dimanche","lundi","mardi","mercredi","jeudi","vendredi","samedi"],"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"},"month_names":[null,"janvier","février","mars","avril","mai","juin","juillet","août","septembre","octobre","novembre","décembre"]}};
+I18n.translations["fr"] = I18n.translations["fr"] || {};
+I18n.translations["fr"]["admin"] = {"edit":{"title":"Editer"},"show":{"note":"plus de détails","title":"Visualiser"}};
+I18n.translations["fr"]["date"] = {"abbr_day_names":["dim","lun","mar","mer","jeu","ven","sam"],"abbr_month_names":[null,"jan.","fév.","mar.","avr.","mai","juin","juil.","août","sept.","oct.","nov.","déc."],"day_names":["dimanche","lundi","mardi","mercredi","jeudi","vendredi","samedi"],"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"},"month_names":[null,"janvier","février","mars","avril","mai","juin","juillet","août","septembre","octobre","novembre","décembre"]};
 EOS
 )
     end
@@ -98,13 +102,17 @@ EOS
       en_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "bits.en.js"))
       expect(en_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = {"date":{"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"}},"number":{"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}}}};
+I18n.translations["en"] = I18n.translations["en"] || {};
+I18n.translations["en"]["date"] = {"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"}};
+I18n.translations["en"]["number"] = {"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}}};
 EOS
 )
       fr_output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "bits.fr.js"))
       expect(fr_output).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["fr"] = {"date":{"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"}},"number":{"currency":{"format":{"format":"%n %u","precision":2,"unit":"€"}}}};
+I18n.translations["fr"] = I18n.translations["fr"] || {};
+I18n.translations["fr"]["date"] = {"formats":{"default":"%d/%m/%Y","long":"%e %B %Y","long_ordinal":"%e %B %Y","only_day":"%e","short":"%e %b"}};
+I18n.translations["fr"]["number"] = {"currency":{"format":{"format":"%n %u","precision":2,"unit":"€"}}};
 EOS
 )
     end
@@ -581,7 +589,14 @@ EOS
         it "exports with the keys sorted" do
           expect(subject).to eq(<<EOS
 I18n.translations || (I18n.translations = {});
-I18n.translations["en"] = {"admin":{"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}},"date":{"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]},"fallback_test":"Success","foo":"Foo","null_test":"fallback for null","number":{"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}},"format":{"delimiter":",","precision":3,"separator":"."}},"time":{"am":"am","formats":{"default":"%a, %d %b %Y %H:%M:%S %z","long":"%B %d, %Y %H:%M","short":"%d %b %H:%M"},"pm":"pm"}};
+I18n.translations["en"] = I18n.translations["en"] || {};
+I18n.translations["en"]["admin"] = {"edit":{"title":"Edit"},"show":{"note":"more details","title":"Show"}};
+I18n.translations["en"]["date"] = {"abbr_day_names":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"abbr_month_names":[null,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"day_names":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"formats":{"default":"%Y-%m-%d","long":"%B %d, %Y","short":"%b %d"},"month_names":[null,"January","February","March","April","May","June","July","August","September","October","November","December"]};
+I18n.translations["en"]["fallback_test"] = "Success";
+I18n.translations["en"]["foo"] = "Foo";
+I18n.translations["en"]["null_test"] = "fallback for null";
+I18n.translations["en"]["number"] = {"currency":{"format":{"delimiter":",","format":"%u%n","precision":2,"separator":".","unit":"$"}},"format":{"delimiter":",","precision":3,"separator":"."}};
+I18n.translations["en"]["time"] = {"am":"am","formats":{"default":"%a, %d %b %Y %H:%M:%S %z","long":"%B %d, %Y %H:%M","short":"%d %b %H:%M"},"pm":"pm"};
 EOS
 )
         end

--- a/spec/js/extend.spec.js
+++ b/spec/js/extend.spec.js
@@ -1,0 +1,41 @@
+var I18n = require("../../app/assets/javascripts/i18n")
+  , Translations = require("./translations")
+;
+
+describe("Extend", function () {
+  it("should return an object", function () {
+    expect(typeof I18n.extend()).toBe('object');
+  });
+
+  it("should merge 2 objects into 1", function () {
+    var obj1 = {
+      test1: "abc"
+    }
+    , obj2 = {
+      test2: "xyz"
+    }
+    , expected = {
+      test1: "abc"
+      , test2: "xyz"
+    };
+
+    expect(I18n.extend(obj1,obj2)).toEqual(expected);
+  });
+  it("should overwrite a property from obj1 with the same property of obj2", function () {
+    var obj1 = {
+      test1: "abc"
+      , test3: "def"
+    }
+    , obj2 = {
+      test2: "xyz"
+      , test3: "uvw"
+    }
+    , expected = {
+      test1: "abc"
+      , test2: "xyz"
+      , test3: "uvw"
+    };
+
+    expect(I18n.extend(obj1,obj2)).toEqual(expected);
+  });
+});

--- a/spec/js/specs.html
+++ b/spec/js/specs.html
@@ -37,6 +37,7 @@
         <script type="text/javascript" src="prepare_options.spec.js"></script>
         <script type="text/javascript" src="translate.spec.js"></script>
         <script type="text/javascript" src="utility_functions.spec.js"></script>
+        <script type="text/javascript" src="extend.spec.js"></script>
 
         <!-- run specs -->
         <script type="text/javascript">

--- a/spec/js/specs_requirejs.html
+++ b/spec/js/specs_requirejs.html
@@ -13,7 +13,7 @@
 
         <!-- load your javascript files -->
         <script type="text/javascript" src="require.js"></script>
-    
+
         <script type="text/javascript">
         // Prepare requirejs shims to wrap each test so that it will work with the
         // require syntax loading
@@ -30,7 +30,8 @@
                 "./pluralization.spec.js",
                 "./prepare_options.spec.js",
                 "./translate.spec.js",
-                "./utility_functions.spec.js"
+                "./utility_functions.spec.js",
+                "./extend.spec.js"
                 ];
         var shims = {};
         for(var i = 0; i < testScripts.length; i++) {

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -64,8 +64,10 @@ describe I18n::JS::Segment do
 
         File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["en"] = {"test":"Test"};
-MyNamespace.translations["fr"] = {"test":"Test2"};
+MyNamespace.translations["en"] = MyNamespace.translations["en"] || {};
+MyNamespace.translations["en"]["test"] = "Test";
+MyNamespace.translations["fr"] = MyNamespace.translations["fr"] || {};
+MyNamespace.translations["fr"]["test"] = "Test2";
         EOF
       end
     end
@@ -79,12 +81,14 @@ MyNamespace.translations["fr"] = {"test":"Test2"};
 
         File.open(File.join(temp_path, "en.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["en"] = {"test":"Test"};
+MyNamespace.translations["en"] = MyNamespace.translations["en"] || {};
+MyNamespace.translations["en"]["test"] = "Test";
         EOF
 
         File.open(File.join(temp_path, "fr.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["fr"] = {"test":"Test2"};
+MyNamespace.translations["fr"] = MyNamespace.translations["fr"] || {};
+MyNamespace.translations["fr"]["test"] = "Test2";
         EOF
       end
     end
@@ -101,7 +105,9 @@ MyNamespace.translations["fr"] = {"test":"Test2"};
 
         File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["en"] = {"a":"Test","b":"Test"};
+MyNamespace.translations["en"] = MyNamespace.translations["en"] || {};
+MyNamespace.translations["en"]["a"] = "Test";
+MyNamespace.translations["en"]["b"] = "Test";
         EOF
       end
     end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -64,10 +64,8 @@ describe I18n::JS::Segment do
 
         File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["en"] = MyNamespace.translations["en"] || {};
-MyNamespace.translations["en"]["test"] = "Test";
-MyNamespace.translations["fr"] = MyNamespace.translations["fr"] || {};
-MyNamespace.translations["fr"]["test"] = "Test2";
+MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || {}), {"test":"Test"});
+MyNamespace.translations["fr"] = I18n.extend((MyNamespace.translations["fr"] || {}), {"test":"Test2"});
         EOF
       end
     end
@@ -81,14 +79,12 @@ MyNamespace.translations["fr"]["test"] = "Test2";
 
         File.open(File.join(temp_path, "en.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["en"] = MyNamespace.translations["en"] || {};
-MyNamespace.translations["en"]["test"] = "Test";
+MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || {}), {"test":"Test"});
         EOF
 
         File.open(File.join(temp_path, "fr.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["fr"] = MyNamespace.translations["fr"] || {};
-MyNamespace.translations["fr"]["test"] = "Test2";
+MyNamespace.translations["fr"] = I18n.extend((MyNamespace.translations["fr"] || {}), {"test":"Test2"});
         EOF
       end
     end
@@ -105,9 +101,7 @@ MyNamespace.translations["fr"]["test"] = "Test2";
 
         File.open(File.join(temp_path, "segment.js")){|f| f.read}.should eql <<-EOF
 MyNamespace.translations || (MyNamespace.translations = {});
-MyNamespace.translations["en"] = MyNamespace.translations["en"] || {};
-MyNamespace.translations["en"]["a"] = "Test";
-MyNamespace.translations["en"]["b"] = "Test";
+MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || {}), {"a":"Test","b":"Test"});
         EOF
       end
     end


### PR DESCRIPTION
@fnando 
    I added the ability for multiple translation files to be added to a single page.  The reason I felt this was so important was so a global and route specific translation file could be precompiled into the rest of my code base properly.  This could also be used on a widget or module level as well as long as the top level properties don't clobber each other.