### PR TITLE
Fix rounding of unprecise floating points in I18n.toNumber()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### bug fixes
 - [Ruby] Fix of missing initializer at sprockets. ([#371](https://github.com/fnando/i18n-js/pull/371))
+- [JS] Correctly round unprecise floating point numbers.
 
 
 ## 3.0.0.rc11

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -38,6 +38,31 @@
     return ("0" + number.toString()).substr(-2);
   };
 
+  // Improved toFixed number rounding function with support for unprecise floating points
+  // JavaScript's standard toFixed function does not round certain numbers correctly (for example 0.105 with precision 2).
+  var toFixed = function(number, precision) {
+    return decimalAdjust('round', number, -precision).toFixed(precision);
+  };
+
+  var decimalAdjust = function(type, value, exp) {
+    // If the exp is undefined or zero...
+    if (typeof exp === 'undefined' || +exp === 0) {
+      return Math[type](value);
+    }
+    value = +value;
+    exp = +exp;
+    // If the value is not a number or the exp is not an integer...
+    if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+      return NaN;
+    }
+    // Shift
+    value = value.toString().split('e');
+    value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+    // Shift back
+    value = value.toString().split('e');
+    return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+  }
+
   // Set default days/months translations.
   var DATE = {
       day_names: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
@@ -529,7 +554,7 @@
     );
 
     var negative = number < 0
-      , string = Math.abs(number).toFixed(options.precision).toString()
+      , string = toFixed(Math.abs(number), options.precision).toString()
       , parts = string.split(".")
       , precision
       , buffer = []

--- a/spec/js/numbers.spec.js
+++ b/spec/js/numbers.spec.js
@@ -97,6 +97,34 @@ describe("Numbers", function(){
     expect(I18n.toNumber(1.98, options)).toEqual("2");
   });
 
+  it("rounds numbers correctly when precision is given", function(){
+    options = {separator: ".", delimiter: ","};
+
+    options["precision"] = 2;
+    expect(I18n.toNumber(0.104, options)).toEqual("0.10");
+
+    options["precision"] = 2;
+    expect(I18n.toNumber(0.105, options)).toEqual("0.11");
+
+    options["precision"] = 2;
+    expect(I18n.toNumber(1.005, options)).toEqual("1.01");
+
+    options["precision"] = 3;
+    expect(I18n.toNumber(35.855, options)).toEqual("35.855");
+
+    options["precision"] = 2;
+    expect(I18n.toNumber(35.855, options)).toEqual("35.86");
+
+    options["precision"] = 1;
+    expect(I18n.toNumber(35.855, options)).toEqual("35.9");
+
+    options["precision"] = 0;
+    expect(I18n.toNumber(35.855, options)).toEqual("36");
+
+    options["precision"] = 0;
+    expect(I18n.toNumber(0.000000000000001, options)).toEqual("0");
+  });
+
   it("returns number as human size", function(){
     var kb = 1024;
 


### PR DESCRIPTION
JavaScript's Float#toFixed method does not round all numbers correctly (or at least not how a human would expect). For example 0.105 is rounded as 0.10 instead of 0.11 when precision is 2. See this thread for more info: http://stackoverflow.com/questions/10015027/javascript-tofixed-not-rounding. Thanks to user2823670 for his improved toFixed implementation.