### PR TITLE
Fix for Sprockets 3.0

### DIFF
--- a/lib/i18n/js/engine.rb
+++ b/lib/i18n/js/engine.rb
@@ -20,7 +20,9 @@ module I18n
         next unless JS::Dependencies.using_asset_pipeline?
         next unless JS::Dependencies.sprockets_supports_register_preprocessor?
 
-        Rails.application.assets.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
+        ##                    (sprockets 2.0 || sprockets 3.0)
+        sprockets = Rails.application.assets || Sprockets
+        sprockets.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
           if context.logical_path == "i18n/filtered"
             ::I18n.load_path.each {|path| context.depend_on(File.expand_path(path))}
           end


### PR DESCRIPTION
If you are using Sprockets 3.0 w/ Rails the application will fail to boot with an error like

```
/home/matt/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/i18n-js-3.0.0.rc11/lib/i18n/js/engine.rb:10:in `block in <class:Engine>': undefined method `register_preprocessor' for nil:NilClass (NoMethodError)
```

The following patch allows the application to boot up again.