### PR TITLE
Replace instanceof checks with their Underscore.js equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Ruby] Fix of missing initializer at sprockets. ([#371](https://github.com/fnando/i18n-js/pull/371))
 - [Ruby] Use proper method to register preprocessor documented by sprockets-rails. ([#376](https://github.com/fnando/i18n-js/pull/376))
 - [JS] Correctly round unprecise floating point numbers.
+- [JS] Ensure objects are recognized when passed in from an iframe. ([#375](https://github.com/fnando/i18n-js/pull/375))
 
 
 ## 3.0.0.rc11

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -111,7 +111,7 @@
     , locale: "en"
     // Set the translation key separator.
     , defaultSeparator: "."
-    // Set the placeholder format. Accepts `{{placeholder}}` and `%{placeholder}`.}
+    // Set the placeholder format. Accepts `{{placeholder}}` and `%{placeholder}`.
     , placeholder: /(?:\{\{|%\{)(.*?)(?:\}\}?)/gm
     // Set if engine should fallback to the default locale when a translation
     // is missing.

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -44,6 +44,22 @@
     return decimalAdjust('round', number, -precision).toFixed(precision);
   };
 
+  // Is a given variable an object?
+  // Borrowed from Underscore.js
+  var isObject = function(obj) {
+    var type = typeof obj;
+    return type === 'function' || type === 'object' && !!obj;
+  };
+
+  // Is a given value an array?
+  // Borrowed from Underscore.js
+  var isArray = function(obj) {
+    if (Array.isArray) {
+      return Array.isArray(obj);
+    };
+    return Object.prototype.toString.call(obj) === '[object Array]';
+  };
+
   var decimalAdjust = function(type, value, exp) {
     // If the exp is undefined or zero...
     if (typeof exp === 'undefined' || +exp === 0) {
@@ -204,7 +220,7 @@
       result = result(locale);
     }
 
-    if (result instanceof Array === false) {
+    if (isArray(result) === false) {
       result = [result];
     }
 
@@ -433,7 +449,7 @@
 
     if (typeof(translation) === "string") {
       translation = this.interpolate(translation, options);
-    } else if (translation instanceof Object && this.isSet(options.count)) {
+    } else if (isObject(translation) && this.isSet(options.count)) {
       translation = this.pluralize(options.count, translation, options);
     }
 
@@ -482,7 +498,7 @@
     options = this.prepareOptions(options);
     var translations, pluralizer, keys, key, message;
 
-    if (scope instanceof Object) {
+    if (isObject(scope)) {
       translations = scope;
     } else {
       translations = this.lookup(scope, options);

--- a/spec/js/locales.spec.js
+++ b/spec/js/locales.spec.js
@@ -1,0 +1,31 @@
+var I18n = require("../../app/assets/javascripts/i18n");
+
+describe("Locales", function(){
+  beforeEach(function(){
+    I18n.reset();
+  });
+
+  it("returns the requested locale, if available", function(){
+    I18n.locales["ab"] = ["ab"];
+    expect(I18n.locales.get("ab")).toEqual(["ab"]);
+  });
+
+  it("wraps single results in an array", function(){
+    I18n.locales["cd"] = "cd";
+    expect(I18n.locales.get("cd")).toEqual(["cd"]);
+  });
+
+  it("returns the result of locale functions", function(){
+    I18n.locales["fn"] = function() {
+      return "gg";
+    };
+    expect(I18n.locales.get("fn")).toEqual(["gg"]);
+  });
+
+  it("uses I18n.locale as a fallback", function(){
+    I18n.locale = "xx";
+    I18n.locales["xx"] = ["xx"];
+    expect(I18n.locales.get()).toEqual(["xx"]);
+    expect(I18n.locales.get("yy")).toEqual(["xx"]);
+  });
+});

--- a/spec/js/specs.html
+++ b/spec/js/specs.html
@@ -31,6 +31,7 @@
         <script type="text/javascript" src="defaults.spec.js"></script>
         <script type="text/javascript" src="interpolation.spec.js"></script>
         <script type="text/javascript" src="localization.spec.js"></script>
+        <script type="text/javascript" src="locales.spec.js"></script>
         <script type="text/javascript" src="numbers.spec.js"></script>
         <script type="text/javascript" src="placeholder.spec.js"></script>
         <script type="text/javascript" src="pluralization.spec.js"></script>


### PR DESCRIPTION
This PR replaces all uses of `instanceof Object` and `instanceof Array` with the `_.isObject` and `_.isArray` functions from the latest Underscore.js release: https://github.com/jashkenas/underscore/blob/1.8.3/underscore.js#L1205-L1215 The reason is that `instanceof` can return `false` for objects and arrays passed between different JavaScript environments, e.g. [between a document and an iframe](http://tobyho.com/2011/01/28/checking-types-in-javascript/). In all other cases, these functions should be equivalent.