### PR TITLE
Use Rails.application.config.assets.configure to load preprocessor

### DIFF
--- a/lib/i18n/js/engine.rb
+++ b/lib/i18n/js/engine.rb
@@ -20,11 +20,13 @@ module I18n
         next unless JS::Dependencies.using_asset_pipeline?
         next unless JS::Dependencies.sprockets_supports_register_preprocessor?
 
-        Rails.application.assets.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
-          if context.logical_path == "i18n/filtered"
-            ::I18n.load_path.each {|path| context.depend_on(File.expand_path(path))}
+        Rails.application.config.assets.configure do |config|
+          config.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
+            if context.logical_path == "i18n/filtered"
+              ::I18n.load_path.each {|path| context.depend_on(File.expand_path(path))}
+            end
+            source
           end
-          source
         end
       end
     end


### PR DESCRIPTION
This fixes issues with Rails.application.assets not being Sprockets in v3.

Related to https://github.com/fnando/i18n-js/pull/374