### PR TITLE
Pass options object to nullPlaceholder and missingPlaceholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### enhancements
   - [JS] Allow extending of translation files ([#354](https://github.com/fnando/i18n-js/pull/354))
+  - [JS] Allow missingPlaceholder to receive extra data for debugging ([#380](https://github.com/fnando/i18n-js/pull/380))
 
 ### bug fixes
 - [Ruby] Fix of missing initializer at sprockets. ([#371](https://github.com/fnando/i18n-js/pull/371))

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -463,9 +463,9 @@
       if (this.isSet(options[name])) {
         value = options[name].toString().replace(/\$/gm, "_#$#_");
       } else if (name in options) {
-        value = this.nullPlaceholder(placeholder, message);
+        value = this.nullPlaceholder(placeholder, message, options);
       } else {
-        value = this.missingPlaceholder(placeholder, message);
+        value = this.missingPlaceholder(placeholder, message, options);
       }
 
       regex = new RegExp(placeholder.replace(/\{/gm, "\\{").replace(/\}/gm, "\\}"));
@@ -527,7 +527,7 @@
   };
 
   // Return a missing placeholder message for given parameters
-  I18n.missingPlaceholder = function(placeholder, message) {
+  I18n.missingPlaceholder = function(placeholder, message, options) {
     return "[missing " + placeholder + " value]";
   };
 

--- a/spec/js/interpolation.spec.js
+++ b/spec/js/interpolation.spec.js
@@ -97,4 +97,17 @@ describe("Interpolation", function(){
     expect(actual).toEqual("Hello !");
     I18n.nullPlaceholder = orig;
   });
+
+  it("provides missingPlaceholder with the placeholder, message, and options object", function(){
+    var orig = I18n.missingPlaceholder;
+    I18n.missingPlaceholder = function(placeholder, message, options) {
+      expect(placeholder).toEqual('{{name}}');
+      expect(message).toEqual('Hello {{name}}!');
+      expect(options.debugScope).toEqual('landing-page');
+      return '[missing-placeholder-debug]';
+    };
+    actual = I18n.t("greetings.name", {debugScope: 'landing-page'});
+    expect(actual).toEqual("Hello [missing-placeholder-debug]!");
+    I18n.missingPlaceholder = orig;
+  });
 });


### PR DESCRIPTION
`I18n.missingPlaceholder` exists so that it can be overridden for debugging purposes (#169). That's why it's passed `message`, even though the default implementation doesn't use it. This PR goes a small step further by also passing `options` to that function. This allows you to pass arbitrary debugging information through `I18n.translate` to `I18n.missingPlaceholder`, e.g. information about which part of the app failed to provide the placeholder.

Related: #285