### PR TITLE
Throw an error when I18n.strftime() takes an invalid date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Nothing
+- [JS] Throw an error when `I18n.strftime()` takes an invalid date ([#383](https://github.com/fnando/i18n-js/pull/383))
+
 
 
 ## [3.0.0.rc12] - 2015-12-30

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -772,6 +772,10 @@
 
     options = this.prepareOptions(options, DATE);
 
+    if (isNaN(date.getTime())) {
+      throw new Error('I18n.strftime() requires a valid date object, but received an invalid date.');
+    }
+
     var weekDay = date.getDay()
       , day = date.getDate()
       , year = date.getFullYear()

--- a/spec/js/dates.spec.js
+++ b/spec/js/dates.spec.js
@@ -255,4 +255,11 @@ describe("Dates", function(){
     date = new Date(2009, 3, 26, 7, 35, 44);
     expect(I18n.strftime(date, "%p")).toEqual("de:AM");
   });
+
+  it("fails to format invalid date", function(){
+    var date = new Date('foo');
+    expect(function() {
+      I18n.strftime(date, "%a");
+    }).toThrow('I18n.strftime() requires a valid date object, but received an invalid date.');
+  });
 });


### PR DESCRIPTION
### Problem

JavaScript `Date` instance can be an `invalid date` in some cases. For example,

```js
// When `Date` constructor takes a valid date string
new Date('20001010'); //=> Tue Oct 10 2000 09:00:00 GMT+0900 (JST)

// When `Date` constructor takes an **invalid** date string
new Date('200010100'); //=> Invalid Date
```

Currently, I18n.strftime produces a wrongly formatted string when it takes an invalid date object. For example,

```js
I18n.strftime(new Date('foo'), '%Y%m%d');
//=> 'NaNaNaN'
```

### Solution

I updated `I18n.strftime` to immediately throw an error when it takes an `invalid date` object. This change prevents it from producing broken strings like `NaNaN`.
