### PR TITLE
Make new "I18n.extend" configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,20 @@ translations:
 ```
 
 
+#### Javscript Deep Merge (:js_extend option)
+
+By default, the output file Javascript will call the `I18n.extend` method to ensure that newly loaded locale
+files are deep-merged with any locale data already in memory. To disable this either globally or per-file,
+set the `js_extend` option to false
+
+```yaml
+js_extend: false # can set here
+translations:
+- file: "public/javascripts/i18n/translations.js"
+  js_extend: false # also here
+```
+
+
 #### Vanilla JavaScript
 
 Just add the `i18n.js` file to your page. You'll have to build the translations object

--- a/README.md
+++ b/README.md
@@ -263,10 +263,10 @@ files are deep-merged with any locale data already in memory. To disable this ei
 set the `js_extend` option to false
 
 ```yaml
-js_extend: false # can set here
+js_extend: false  # this will disable Javascript I18n.extend globally
 translations:
 - file: "public/javascripts/i18n/translations.js"
-  js_extend: false # also here
+  js_extend: false  # this will disable Javascript I18n.extend for this file
 ```
 
 

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -48,13 +48,11 @@ module I18n
         only = options[:only] || '*'
         exceptions = [options[:except] || []].flatten
 
-        segment_options = options.slice(:namespace, :pretty_print)
-
         result = segment_for_scope(only, exceptions)
 
         merge_with_fallbacks!(result) if fallbacks
 
-        segments << Segment.new(file, result, segment_options) unless result.empty?
+        segments << Segment.new(file, result, extract_segment_options(options)) unless result.empty?
 
         segments
       end
@@ -168,6 +166,13 @@ module I18n
       end
     end
 
+    def self.js_extend
+      config.fetch(:js_extend) do
+        # default value
+        true
+      end
+    end
+
     def self.sort_translation_keys?
       @sort_translation_keys ||= (config[:sort_translation_keys]) if config.has_key?(:sort_translation_keys)
       @sort_translation_keys = true if @sort_translation_keys.nil?
@@ -176,6 +181,11 @@ module I18n
 
     def self.sort_translation_keys=(value)
       @sort_translation_keys = !!value
+    end
+
+    def self.extract_segment_options(options)
+      segment_options = {js_extend: js_extend, sort_translation_keys: sort_translation_keys?}.with_indifferent_access
+      segment_options.merge(options.slice(*Segment::OPTIONS))
     end
 
     ### Export i18n.js

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -141,7 +141,7 @@ module I18n
           results[scope.to_sym] = tmp unless tmp.nil?
         end
         return results
-      elsif translations.respond_to?(:has_key?) && translations.has_key?(scope.to_sym)
+      elsif translations.respond_to?(:key?) && translations.key?(scope.to_sym)
         return {scope.to_sym => scopes.empty? ? translations[scope.to_sym] : filter(translations[scope.to_sym], scopes)}
       end
       nil
@@ -174,7 +174,7 @@ module I18n
     end
 
     def self.sort_translation_keys?
-      @sort_translation_keys ||= (config[:sort_translation_keys]) if config.has_key?(:sort_translation_keys)
+      @sort_translation_keys ||= (config[:sort_translation_keys]) if config.key?(:sort_translation_keys)
       @sort_translation_keys = true if @sort_translation_keys.nil?
       @sort_translation_keys
     end
@@ -202,7 +202,7 @@ module I18n
       end
 
       def self.export_i18n_js_dir_path
-        @export_i18n_js_dir_path ||= (config[:export_i18n_js] || :none) if config.has_key?(:export_i18n_js)
+        @export_i18n_js_dir_path ||= (config[:export_i18n_js] || :none) if config.key?(:export_i18n_js)
         @export_i18n_js_dir_path ||= DEFAULT_EXPORT_DIR_PATH
         @export_i18n_js_dir_path
       end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -3,7 +3,7 @@ module I18n
 
     # Class which enscapulates a translations hash and outputs a single JSON translation file
     class Segment
-      OPTIONS = [:namespace, :pretty_print, :js_extend, :sort_translation_keys]
+      OPTIONS = [:namespace, :pretty_print, :js_extend, :sort_translation_keys].freeze
       LOCALE_INTERPOLATOR = /%\{locale\}/
 
       attr_reader *([:file, :translations] | OPTIONS)
@@ -13,8 +13,8 @@ module I18n
         @translations = translations
         @namespace    = options[:namespace] || 'I18n'
         @pretty_print = !!options[:pretty_print]
-        @js_extend    = options.has_key?(:js_extend) ? !!options[:js_extend] : true
-        @sort_translation_keys = options.has_key?(:sort_translation_keys) ? !!options[:sort_translation_keys] : true
+        @js_extend    = options.key?(:js_extend) ? !!options[:js_extend] : true
+        @sort_translation_keys = options.key?(:sort_translation_keys) ? !!options[:sort_translation_keys] : true
       end
 
       # Saves JSON file containing translations

--- a/spec/fixtures/js_extend_parent.yml
+++ b/spec/fixtures/js_extend_parent.yml
@@ -1,0 +1,6 @@
+fallbacks: false
+js_extend: false
+
+translations:
+  - file: "tmp/i18n-js/js_extend_parent.js"
+    only: "*.date.formats"

--- a/spec/fixtures/js_extend_segment.yml
+++ b/spec/fixtures/js_extend_segment.yml
@@ -1,0 +1,6 @@
+fallbacks: false
+
+translations:
+  - file: "tmp/i18n-js/js_extend_segment.js"
+    js_extend: false
+    only: "*.date.formats"

--- a/spec/ruby/i18n/js_spec.rb
+++ b/spec/ruby/i18n/js_spec.rb
@@ -30,14 +30,14 @@ describe I18n::JS do
 
     it "exports messages using custom output path" do
       set_config "custom_path.yml"
-      I18n::JS::Segment.should_receive(:new).with("tmp/i18n-js/all.js", translations, {}).and_call_original
+      I18n::JS::Segment.should_receive(:new).with("tmp/i18n-js/all.js", translations, {js_extend: true, sort_translation_keys: true}).and_call_original
       I18n::JS::Segment.any_instance.should_receive(:save!).with(no_args)
       I18n::JS.export
     end
 
     it "sets default scope to * when not specified" do
       set_config "no_scope.yml"
-      I18n::JS::Segment.should_receive(:new).with("tmp/i18n-js/no_scope.js", translations, {}).and_call_original
+      I18n::JS::Segment.should_receive(:new).with("tmp/i18n-js/no_scope.js", translations, {js_extend: true, sort_translation_keys: true}).and_call_original
       I18n::JS::Segment.any_instance.should_receive(:save!).with(no_args)
       I18n::JS.export
     end
@@ -587,6 +587,41 @@ EOS
         end
       end
     end
+  end
 
+  describe "js_extend option" do
+    before do
+      stub_const('I18n::JS::DEFAULT_EXPORT_DIR_PATH', temp_path)
+    end
+
+    it "exports with js_extend option at parent level" do
+      set_config "js_extend_parent.yml"
+      I18n::JS.export
+
+      file_should_exist "js_extend_parent.js"
+
+      output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "js_extend_parent.js"))
+      expect(output).to eq(<<EOS
+I18n.translations || (I18n.translations = {});
+I18n.translations[\"en\"] = {\"date\":{\"formats\":{\"default\":\"%Y-%m-%d\",\"long\":\"%B %d, %Y\",\"short\":\"%b %d\"}}};
+I18n.translations[\"fr\"] = {\"date\":{\"formats\":{\"default\":\"%d/%m/%Y\",\"long\":\"%e %B %Y\",\"long_ordinal\":\"%e %B %Y\",\"only_day\":\"%e\",\"short\":\"%e %b\"}}};
+EOS
+)
+    end
+
+    it "exports with js_extend option at segment level" do
+      set_config "js_extend_segment.yml"
+      I18n::JS.export
+
+      file_should_exist "js_extend_segment.js"
+
+      output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "js_extend_segment.js"))
+      expect(output).to eq(<<EOS
+I18n.translations || (I18n.translations = {});
+I18n.translations[\"en\"] = {\"date\":{\"formats\":{\"default\":\"%Y-%m-%d\",\"long\":\"%B %d, %Y\",\"short\":\"%b %d\"}}};
+I18n.translations[\"fr\"] = {\"date\":{\"formats\":{\"default\":\"%d/%m/%Y\",\"long\":\"%e %B %Y\",\"long_ordinal\":\"%e %B %Y\",\"only_day\":\"%e\",\"short\":\"%e %b\"}}};
+EOS
+)
+    end
   end
 end


### PR DESCRIPTION
Many users (myself included) have issues with the new `I18n.extend` which was recently added to the Javascript.

This PR adds "js_extend" option which controls whether or not to use "I18n.extend" in your output files. This can be specified at both segment (single file) and parent level (all files).

I've also made "sort_translation_keys" to be settable at both segment and parent level to be consistent.

This PR contains some light refactoring within the `Segment` class for clarity/readability.
