### PR TITLE
Init missingBehaviour and missingTranslationPrefix

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -191,6 +191,12 @@
 
     if (typeof(this.translations) === "undefined" && this.translations !== null)
       this.translations = DEFAULT_OPTIONS.translations;
+      
+    if (typeof(this.missingBehaviour) === "undefined" && this.missingBehaviour !== null)
+      this.missingBehaviour = DEFAULT_OPTIONS.missingBehaviour;
+
+    if (typeof(this.missingTranslationPrefix) === "undefined" && this.missingTranslationPrefix !== null)
+      this.missingTranslationPrefix = DEFAULT_OPTIONS.missingTranslationPrefix;
   };
   I18n.initializeOptions();
 


### PR DESCRIPTION
Fixes a JS error that occurs in `I18n.missingTranslation` when `missingBehaviour` is set to `guess` without setting `missingTranslationPrefix`.

![image](https://cloud.githubusercontent.com/assets/7904/13821307/6815aea2-eb77-11e5-8751-795ba187c9c4.png)
