### PR TITLE
Update link to NPM-Package to v3.0.0.rc12 from rc8

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ by hand or using your favorite programming language. More info below.
 
 Add the following line to your package.json dependencies (where version is the version you want - n.b. npm install requires it to be the gzipped tarball, see [npm install](https://www.npmjs.org/doc/cli/npm-install.html))
 ```javascript
-"i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc8.tar.gz"
+"i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz"
 ```
 Run npm install then use via
 ```javascript


### PR DESCRIPTION
The rc8-Version does not have the `.extend()` method implemented, so if you use the rails-gem as well as the NPM-package with rc8, Javscript complains that `.extend()` is missing.