### PR TITLE
Bugfix: make i18n-js compatible with rails 5

### DIFF
--- a/lib/i18n/js/dependencies.rb
+++ b/lib/i18n/js/dependencies.rb
@@ -12,6 +12,10 @@ module I18n
           safe_gem_check("rails", "~> 4.0", ">= 4.0.0.beta1") && running_rails4?
         end
 
+        def rails5?
+          safe_gem_check("rails", "~> 5.0", ">= 5.0.0.beta1") && running_rails5?
+        end
+
         def sprockets_supports_register_preprocessor?
           defined?(Sprockets) && Sprockets.respond_to?(:register_preprocessor)
         end
@@ -26,7 +30,7 @@ module I18n
 
         def using_asset_pipeline?
           assets_pipeline_available =
-            (rails3? || rails4?) &&
+            (rails3? || rails4? || rails5?) &&
             Rails.respond_to?(:application) &&
             Rails.application.respond_to?(:assets)
           rails3_assets_enabled =
@@ -34,7 +38,7 @@ module I18n
             assets_pipeline_available &&
             Rails.application.config.assets.enabled != false
 
-          assets_pipeline_available && (rails4? || rails3_assets_enabled)
+          assets_pipeline_available && (rails4? || rails5? || rails3_assets_enabled)
         end
 
         private
@@ -45,6 +49,10 @@ module I18n
 
         def running_rails4?
           running_rails? && Rails.version.to_i == 4
+        end
+
+        def running_rails5?
+          running_rails? && Rails.version.to_i == 5
         end
 
         def running_rails?


### PR DESCRIPTION
I, this is a little fix to the open issue #404 to be able to use I18n-js with Rails 5 and asset pipeline. I think it will be more interesting to merge rails4 and rails5 methods since it's the same behavior. To discuss. 