### PR TITLE
* Support sprockets 2, 3 and 4 when registering preprocessor

### DIFF
--- a/lib/i18n/js/dependencies.rb
+++ b/lib/i18n/js/dependencies.rb
@@ -28,6 +28,10 @@ module I18n
           safe_gem_check("rails", '>= 3.0.0.beta')
         end
 
+        # This cannot be called at class definition time
+        # Since not all libraries are loaded
+        #
+        # Call this in an initializer
         def using_asset_pipeline?
           assets_pipeline_available =
             (rails3? || rails4? || rails5?) &&

--- a/lib/i18n/js/engine.rb
+++ b/lib/i18n/js/engine.rb
@@ -2,38 +2,90 @@ require "i18n/js"
 
 module I18n
   module JS
-    class Engine < ::Rails::Engine
-      # `sprockets.environment` was used for 1.x of `sprockets-rails`
-      # https://github.com/rails/sprockets-rails/issues/227
-      #
-      # References for current values:
-      #
-      # Here is where sprockets are attached with Rails. There is no 'sprockets.environment' mentioned.
-      # https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb
-      #
-      # Finisher hook is the place which should be used as border.
-      # http://guides.rubyonrails.org/configuring.html#initializers
-      #
-      # For detail see Pull Request:
-      # https://github.com/fnando/i18n-js/pull/371
-      initializer "i18n-js.register_preprocessor", after: :engines_blank_point, before: :finisher_hook do
-        next unless JS::Dependencies.using_asset_pipeline?
-        next unless JS::Dependencies.sprockets_supports_register_preprocessor?
+    # @api private
+    # The class cannot be private
+    class SprocketsExtension
+      # Actual definition is placed below
+    end
 
-        # From README of 2.x & 3.x of `sprockets-rails`
-        # It seems the `configure` block is preferred way to call `register_preprocessor`
-        # Not sure if this will break older versions of rails
+    class Engine < ::Rails::Engine
+      if JS::Dependencies.sprockets_supports_register_preprocessor?
+        # constant `Sprockets` should be available here after
+        # `.sprockets_supports_register_preprocessor?` called
+        sprockets_version = Gem::Version.new(Sprockets::VERSION).release
+        v2_only = Gem::Dependency.new("", " ~> 2")
+        v3_plus = Gem::Dependency.new("", " >= 3")
+
+        # See https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
+        # for reference of supporting multiple versions
+
+        # `sprockets.environment` was used for 1.x of `sprockets-rails`
+        # https://github.com/rails/sprockets-rails/issues/227
         #
-        # https://github.com/rails/sprockets-rails/blob/v2.3.3/README.md
-        # https://github.com/rails/sprockets-rails/blob/v3.0.0/README.md
-        Rails.application.config.assets.configure do |config|
-          config.register_preprocessor "application/javascript", :"i18n-js_dependencies" do |context, source|
-            if context.logical_path == "i18n/filtered"
-              ::I18n.load_path.each {|path| context.depend_on(File.expand_path(path))}
-            end
-            source
+        # References for current values:
+        #
+        # Here is where sprockets are attached with Rails. There is no 'sprockets.environment' mentioned.
+        # https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb
+        #
+        # Finisher hook is the place which should be used as border.
+        # http://guides.rubyonrails.org/configuring.html#initializers
+        #
+        # For detail see Pull Request:
+        # https://github.com/fnando/i18n-js/pull/371
+        initializer_args = case sprockets_version
+        when -> (v) { v2_only.match?("", v) || v3_plus.match?("", v) }
+          { after: :engines_blank_point, before: :finisher_hook }
+        else
+          raise StandardError, "Sprockets version #{sprockets_version} is not supported"
+        end
+
+        initializer "i18n-js.register_preprocessor", initializer_args do
+          # This must be called inside initializer block
+          # For details see comments for `using_asset_pipeline?`
+          next unless JS::Dependencies.using_asset_pipeline?
+
+          # From README of 2.x & 3.x of `sprockets-rails`
+          # It seems the `configure` block is preferred way to call `register_preprocessor`
+          # Not sure if this will break older versions of rails
+          #
+          # https://github.com/rails/sprockets-rails/blob/v2.3.3/README.md
+          # https://github.com/rails/sprockets-rails/blob/v3.0.0/README.md
+          Rails.application.config.assets.configure do |config|
+            config.register_preprocessor(
+              "application/javascript",
+              ::I18n::JS::SprocketsExtension,
+            )
           end
         end
+      end
+    end
+
+    # @api private
+    class SprocketsExtension
+      def initialize(filename, &block)
+        @filename = filename
+        @source   = block.call
+      end
+
+      def render(context, empty_hash_wtf)
+        self.class.run(@filename, @source, context)
+      end
+
+      def self.run(filename, source, context)
+        if context.logical_path == "i18n/filtered"
+          ::I18n.load_path.each { |path| context.depend_on(File.expand_path(path)) }
+        end
+
+        source
+      end
+
+      def self.call(input)
+        filename = input[:filename]
+        source   = input[:data]
+        context  = input[:environment].context_class.new(input)
+
+        result = run(filename, source, context)
+        context.metadata.merge(data: result)
       end
     end
   end


### PR DESCRIPTION
Same purpose as #417
Also:
- fix issue when `Sprockets` not defined
- remove `silence_deprecation` since we have no idea what other deprecations are there
- keep existing initializer arguments
- keep existing comments

### Testing
- run `rake assets:clobber` (I am using rails 4.1, so maybe for you it's a different task)
  Without running this it doesn't work at all
- Start rails app
- Visit local website, open console, get a translation value with `I18n.t`
- Change value in transalation file
- Refresh page, get translation value again, it should be changed

### Test Results

#### Test 1
Run by PikachuEXE before submitting this PR

sprockets (2.12.4)
sprockets-rails (2.3.3)
rails (4.1.16)

Result: Translation value updated correctly

#### [Test 2](https://github.com/fnando/i18n-js/pull/417#issuecomment-241336276)
Sprockets 3.7

Result: "works"