### PR TITLE
Allow numeric and boolean values in YAML

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -53,11 +53,19 @@
 
   // Is a given value an array?
   // Borrowed from Underscore.js
-  var isArray = function(obj) {
+  var isArray = function(val) {
     if (Array.isArray) {
-      return Array.isArray(obj);
+      return Array.isArray(val);
     };
-    return Object.prototype.toString.call(obj) === '[object Array]';
+    return Object.prototype.toString.call(val) === '[object Array]';
+  };
+
+  var isString = function(val) {
+    return typeof value == 'string' || Object.prototype.toString.call(val) === '[object String]'
+  };
+
+  var isNumber = function(val) {
+    return typeof val == 'number' || Object.prototype.toString.call(val) === '[object Number]'
   };
 
   var decimalAdjust = function(type, value, exp) {
@@ -83,7 +91,7 @@
     var key, value;
     for (key in obj) if (obj.hasOwnProperty(key)) {
       value = obj[key];
-      if (Object.prototype.toString.call(value) === '[object String]') {
+      if (isString(value) || isNumber(value)) {
         dest[key] = value;
       } else {
         if (dest[key] == null) dest[key] = {};

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -61,11 +61,15 @@
   };
 
   var isString = function(val) {
-    return typeof value == 'string' || Object.prototype.toString.call(val) === '[object String]'
+    return typeof value == 'string' || Object.prototype.toString.call(val) === '[object String]';
   };
 
   var isNumber = function(val) {
-    return typeof val == 'number' || Object.prototype.toString.call(val) === '[object Number]'
+    return typeof val == 'number' || Object.prototype.toString.call(val) === '[object Number]';
+  };
+
+  var isBoolean = function(val) {
+    return val === true || val === false;
   };
 
   var decimalAdjust = function(type, value, exp) {
@@ -91,7 +95,7 @@
     var key, value;
     for (key in obj) if (obj.hasOwnProperty(key)) {
       value = obj[key];
-      if (isString(value) || isNumber(value)) {
+      if (isString(value) || isNumber(value) || isBoolean(value)) {
         dest[key] = value;
       } else {
         if (dest[key] == null) dest[key] = {};

--- a/spec/js/extend.spec.js
+++ b/spec/js/extend.spec.js
@@ -58,5 +58,26 @@ describe("Extend", function () {
     }
 
     expect(I18n.extend(obj1, obj2)).toEqual(expected);
-  })
+  });
+
+  it("should merge both numbers and string", function() {
+    var obj1 = {
+      test1: {
+        test2: 43
+      }
+    }
+    , obj2 = {
+      test1: {
+        test3: 23
+      }
+    }
+    , expected = {
+      test1: {
+        test2: 43
+        , test3: 23
+      }
+    }
+
+    expect(I18n.extend(obj1, obj2)).toEqual(expected);
+  });
 });

--- a/spec/js/extend.spec.js
+++ b/spec/js/extend.spec.js
@@ -60,21 +60,23 @@ describe("Extend", function () {
     expect(I18n.extend(obj1, obj2)).toEqual(expected);
   });
 
-  it("should merge both numbers and string", function() {
+  it("should correctly merge string, numberic and boolean values", function() {
     var obj1 = {
       test1: {
-        test2: 43
+        test2: false
       }
     }
     , obj2 = {
       test1: {
-        test3: 23
+        test3: 23,
+        test4: 'abc'
       }
     }
     , expected = {
       test1: {
-        test2: 43
+        test2: false
         , test3: 23
+        , test4: 'abc'
       }
     }
 


### PR DESCRIPTION
When merging in values from YAML, I18n-js currently only treats string's and objects as valid values. If a key is set to a number or boolean it will not propagate through to i18n-js, and will instead return an object.

*YAML:*

```yml
currency:
  precision: 2
  delimiter: ','
  strip_insignificant_zeros: false
```

*Before:*

```js
{
  currency: {
    precision: {},
    delimiter: ',',
    strip_insignificant_zeros: {}
  }
}
```

*After:*

```js
{
  currency: {
    precision: 2,
    delimiter: ',',
    strip_insignificant_zeros: false
  }
}
```