### PR TITLE
Fix for merge so that numbers don't get turned into {}'s

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -83,7 +83,7 @@
     var key, value;
     for (key in obj) if (obj.hasOwnProperty(key)) {
       value = obj[key];
-      valueType = Object.prototype.toString.call(value);
+      var valueType = Object.prototype.toString.call(value);
       if (valueType === '[object String]' || valueType === '[object Array]' || valueType === '[object Number]') {
         dest[key] = value;
       } else {

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -83,7 +83,8 @@
     var key, value;
     for (key in obj) if (obj.hasOwnProperty(key)) {
       value = obj[key];
-      if (Object.prototype.toString.call(value) === '[object String]') {
+      valueType = Object.prototype.toString.call(value);
+      if (valueType === '[object String]' || valueType === '[object Array]' || valueType === '[object Number]') {
         dest[key] = value;
       } else {
         if (dest[key] == null) dest[key] = {};


### PR DESCRIPTION
Since upgrading to the latest version of i18n-js we started having issues with `I18n.toNumber` - it would always result in `NaN`.

Debugging it showed that our `numbers.format` localisation was actually coming through I18n as:
![image](https://cloud.githubusercontent.com/assets/97317/18264910/415e6e1c-7456-11e6-831e-e26441583329.png)

Where what we expected was:
![image](https://cloud.githubusercontent.com/assets/97317/18264919/4ac31872-7456-11e6-97ee-374d9b19416a.png)

This was traced back to the merge method in i18n.js. It treated strings correctly, but not  booleans/numbers/array. A simple test case for this follows:

```javascript
I18n.extend({cats: 1}, {cats: 1})
// {cats: 1}
I18n.extend({}, {cats: 1})
// {cats: {}}
```
