### PR TITLE
Remove fallback locale validation

### DIFF
--- a/lib/i18n/js/fallback_locales.rb
+++ b/lib/i18n/js/fallback_locales.rb
@@ -32,7 +32,6 @@ module I18n
                   end
 
         locales.map! { |locale| locale.to_sym }
-        ensure_valid_locales!(locales)
         locales
       end
 
@@ -65,16 +64,6 @@ module I18n
         return if fallbacks.all? { |e| e.is_a?(String) || e.is_a?(Symbol) }
 
         fail ArgumentError, "If fallbacks is passed as Array, it must ony include Strings or Symbols. Given: #{fallbacks}"
-      end
-
-      # Ensures that only valid locales are returned.
-      #
-      # @note
-      #   This ignores option `I18n.enforce_available_locales`
-      def ensure_valid_locales!(locales)
-        if locales.any? { |locale| !::I18n.available_locales.include?(locale) }
-          fail ArgumentError, "Valid locales: #{::I18n.available_locales.join(", ")} - Given Locales: #{locales.join(", ")}"
-        end
       end
     end
   end

--- a/spec/ruby/i18n/js/fallback_locales_spec.rb
+++ b/spec/ruby/i18n/js/fallback_locales_spec.rb
@@ -42,21 +42,11 @@ describe I18n::JS::FallbackLocales do
 
     context "when given a invalid locale as fallbacks" do
       let(:fallbacks) { :invalid_locale }
-      it { expect(fetching_locales).to raise_error(ArgumentError) }
+      it { should eq([:invalid_locale]) }
     end
 
     context "when given a invalid type as fallbacks" do
       let(:fallbacks) { 42 }
-      it { expect(fetching_locales).to raise_error(ArgumentError) }
-    end
-
-    context "when given an invalid Array as fallbacks" do
-      let(:fallbacks) { [:de, :en, :invalid_locale] }
-      it { expect(fetching_locales).to raise_error(ArgumentError) }
-    end
-
-    context "when given a invalid Hash as fallbacks" do
-      let(:fallbacks) do { :fr => [:de, :en, :invalid_locale] } end
       it { expect(fetching_locales).to raise_error(ArgumentError) }
     end
 


### PR DESCRIPTION
(From issue #423)

Whatever the use case, if we want i18n-js to behave more like Rails, we shouldn't check if all fallback locales are specified under `I18n.available_locales`, because Rails doesn't.