### PR TITLE
Fix/missing dependency

### DIFF
--- a/i18n-js.gemspec
+++ b/i18n-js.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "i18n", "~> 0.6", ">= 0.6.6"
   s.add_development_dependency "appraisal", "~> 2.0"
-  s.add_development_dependency "activesupport", ">= 3.2.22"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "gem-release", ">= 0.7"

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -162,7 +162,14 @@ module I18n
     def self.translations
       ::I18n.backend.instance_eval do
         init_translations unless initialized?
-        translations.slice(*::I18n.available_locales)
+        # When activesupport is absent,
+        # the core extension (`#slice`) from `i18n` gem will be used instead
+        # And it's causing errors (at least in test)
+        #
+        # So the input is wrapped by our class for better `#slice`
+        Private::HashWithSymbolKeys.new(translations).
+          slice(*::I18n.available_locales).
+          to_h
       end
     end
 

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -1,7 +1,9 @@
 require "yaml"
-require "i18n"
 require "fileutils"
+require "i18n"
+
 require "i18n/js/utils"
+require "i18n/js/private/hash_with_symbol_keys"
 
 module I18n
   module JS
@@ -43,16 +45,23 @@ module I18n
     end
 
     def self.configured_segments
-      config[:translations].inject([]) do |segments, options|
-        file = options[:file]
-        only = options[:only] || '*'
-        exceptions = [options[:except] || []].flatten
+      config[:translations].inject([]) do |segments, options_hash|
+        options_hash_with_symbol_keys = Private::HashWithSymbolKeys.new(options_hash)
+        file = options_hash_with_symbol_keys[:file]
+        only = options_hash_with_symbol_keys[:only] || '*'
+        exceptions = [options_hash_with_symbol_keys[:except] || []].flatten
 
         result = segment_for_scope(only, exceptions)
 
         merge_with_fallbacks!(result) if fallbacks
 
-        segments << Segment.new(file, result, extract_segment_options(options)) unless result.empty?
+        unless result.empty?
+          segments << Segment.new(
+            file,
+            result,
+            extract_segment_options(options_hash_with_symbol_keys),
+          )
+        end
 
         segments
       end
@@ -91,11 +100,13 @@ module I18n
     # custom output directory
     def self.config
       if config?
-        erb = ERB.new(File.read(config_file_path)).result
-        (YAML.load(erb) || {}).with_indifferent_access
+        erb_result_from_yaml_file = ERB.new(File.read(config_file_path)).result
+        Private::HashWithSymbolKeys.new(
+          (::YAML.load(erb_result_from_yaml_file) || {})
+        )
       else
-        {}
-      end
+        Private::HashWithSymbolKeys.new({})
+      end.freeze
     end
 
     # Check if configuration file exist
@@ -184,7 +195,10 @@ module I18n
     end
 
     def self.extract_segment_options(options)
-      segment_options = {js_extend: js_extend, sort_translation_keys: sort_translation_keys?}.with_indifferent_access
+      segment_options = Private::HashWithSymbolKeys.new({
+        js_extend: js_extend,
+        sort_translation_keys: sort_translation_keys?,
+      }).freeze
       segment_options.merge(options.slice(*Segment::OPTIONS))
     end
 

--- a/lib/i18n/js/private/hash_with_symbol_keys.rb
+++ b/lib/i18n/js/private/hash_with_symbol_keys.rb
@@ -1,0 +1,36 @@
+module I18n
+  module JS
+    # @api private
+    module Private
+      # Hash with string keys converted to symbol keys
+      # Used for handling values read on YAML
+      #
+      # @api private
+      class HashWithSymbolKeys < ::Hash
+        # An instance can only be created by passing in another hash
+        def initialize(hash)
+          raise TypeError unless hash.is_a?(::Hash)
+
+          hash.each_key do |key|
+            # Objects like `Integer` does not have `to_sym`
+            new_key = key.respond_to?(:to_sym) ? key.to_sym : key
+            self[new_key] = hash[key]
+          end
+
+          self.default = hash.default if hash.default
+          self.default_proc = hash.default_proc if hash.default_proc
+
+          freeze
+        end
+
+        # From AS Core extension
+        def slice(*keys)
+          hash = keys.each_with_object(Hash.new) do |k, hash|
+            hash[k] = self[k] if has_key?(k)
+          end
+          self.class.new(hash)
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -1,3 +1,5 @@
+require "i18n/js/private/hash_with_symbol_keys"
+
 module I18n
   module JS
 
@@ -10,7 +12,13 @@ module I18n
 
       def initialize(file, translations, options = {})
         @file         = file
-        @translations = translations
+        # `#slice` will be used
+        # But when activesupport is absent,
+        # the core extension from `i18n` gem will be used instead
+        # And it's causing errors (at least in test)
+        #
+        # So the input is wrapped by our class for better `#slice`
+        @translations = Private::HashWithSymbolKeys.new(translations)
         @namespace    = options[:namespace] || 'I18n'
         @pretty_print = !!options[:pretty_print]
         @js_extend    = options.key?(:js_extend) ? !!options[:js_extend] : true

--- a/spec/ruby/i18n/js_spec.rb
+++ b/spec/ruby/i18n/js_spec.rb
@@ -405,7 +405,7 @@ EOS
     it "executes erb in config file" do
       set_config "erb.yml"
 
-      config_entry = I18n::JS.config["translations"].first
+      config_entry = I18n::JS.config[:translations].first
       config_entry["only"].should eq("*.date.formats")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require "i18n"
 require "json"
 
-require "active_support/all"
 require "i18n/js"
 
 module Helpers


### PR DESCRIPTION
This PR removes development dependency `activesupport`
Which is actually a hidden runtime dependency
since `with_indifferent_access` and `slice` are used

`with_indifferent_access` is from `activesupport`
`slice` is from `activesupport` 
(although `i18n` also "provide" `slice`, but it won't be used if `activesupport` is loaded first)

The test pass but not sure if it's working properly for everyone