### PR TITLE
Add available_locales config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ translations:
 ```
 
 
-#### Javscript Deep Merge (:js_extend option)
+#### Javascript Deep Merge (:js_extend option)
 
 By default, the output file Javascript will call the `I18n.extend` method to ensure that newly loaded locale
 files are deep-merged with any locale data already in memory. To disable this either globally or per-file,
@@ -267,6 +267,17 @@ js_extend: false  # this will disable Javascript I18n.extend globally
 translations:
 - file: "public/javascripts/i18n/translations.js"
   js_extend: false  # this will disable Javascript I18n.extend for this file
+```
+
+#### Specify locales to be used in Javascript
+
+If you want to specify locales for Javascript, use the `available_locales` option (default: `I18n.available_locales`).
+
+```yaml
+available_locales:
+  - en
+  - fr
+  - it
 ```
 
 

--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -60,7 +60,7 @@ module I18n
 
     # deep_merge! given result with result for fallback locale
     def self.merge_with_fallbacks!(result)
-      I18n.available_locales.each do |locale|
+      available_locales.each do |locale|
         fallback_locales = FallbackLocales.new(fallbacks, locale)
         fallback_locales.each do |fallback_locale|
           # `result[fallback_locale]` could be missing
@@ -149,10 +149,13 @@ module I18n
 
     # Initialize and return translations
     def self.translations
-      ::I18n.backend.instance_eval do
+      backend_translations = ::I18n.backend.instance_eval do
         init_translations unless initialized?
-        translations.slice(*::I18n.available_locales)
+        translations
       end
+
+      return backend_translations if available_locales.empty?
+      backend_translations.slice(*available_locales)
     end
 
     def self.use_fallbacks?
@@ -186,6 +189,13 @@ module I18n
     def self.extract_segment_options(options)
       segment_options = {js_extend: js_extend, sort_translation_keys: sort_translation_keys?}.with_indifferent_access
       segment_options.merge(options.slice(*Segment::OPTIONS))
+    end
+
+    def self.available_locales
+      config.fetch(:available_locales) do
+        # default value
+        I18n.available_locales rescue []
+      end
     end
 
     ### Export i18n.js

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -3,24 +3,25 @@ module I18n
 
     # Class which enscapulates a translations hash and outputs a single JSON translation file
     class Segment
-      OPTIONS = [:namespace, :pretty_print, :js_extend, :sort_translation_keys].freeze
+      OPTIONS = [:namespace, :pretty_print, :js_extend, :sort_translation_keys, :available_locales].freeze
       LOCALE_INTERPOLATOR = /%\{locale\}/
 
       attr_reader *([:file, :translations] | OPTIONS)
 
       def initialize(file, translations, options = {})
-        @file         = file
-        @translations = translations
-        @namespace    = options[:namespace] || 'I18n'
-        @pretty_print = !!options[:pretty_print]
-        @js_extend    = options.key?(:js_extend) ? !!options[:js_extend] : true
+        @file                  = file
+        @translations          = translations
+        @namespace             = options[:namespace] || 'I18n'
+        @pretty_print          = !!options[:pretty_print]
+        @js_extend             = options.key?(:js_extend) ? !!options[:js_extend] : true
         @sort_translation_keys = options.key?(:sort_translation_keys) ? !!options[:sort_translation_keys] : true
+        @available_locales     = options[:available_locales] || I18n.available_locales rescue []
       end
 
       # Saves JSON file containing translations
       def save!
         if @file =~ LOCALE_INTERPOLATOR
-          I18n.available_locales.each do |locale|
+          available_locales.each do |locale|
             write_file(file_for_locale(locale), @translations.slice(locale))
           end
         else

--- a/spec/ruby/i18n/js_spec.rb
+++ b/spec/ruby/i18n/js_spec.rb
@@ -367,9 +367,11 @@ EOS
     end
   end
 
-  context "I18n.available_locales" do
+  context "available_locales" do
 
-    context "when I18n.available_locales is not set" do
+    context "when available_locales is not set" do
+      before { allow(I18n::JS).to receive(:available_locales).and_return([]) }
+
       it "should allow all locales" do
         result = I18n::JS.scoped_translations("*.admin.*.title")
 
@@ -379,8 +381,8 @@ EOS
       end
     end
 
-    context "when I18n.available_locales is set" do
-      before { allow(::I18n).to receive(:available_locales){ [:en, :fr] } }
+    context "when available_locales is set" do
+      before { allow(I18n::JS).to receive(:available_locales) { [:en, :fr] } }
 
       it "should ignore non-valid locales" do
         result = I18n::JS.scoped_translations("*.admin.*.title")


### PR DESCRIPTION
This option allows to specify locales to use in Javascript. Defaults to `I18n.available_locales`. See #423 
