### PR TITLE
Add fallback to pluralize

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -347,6 +347,8 @@
       , locale
       , scopes
       , translations
+      , keys
+      , key
     ;
 
     scope = this.getFullScope(scope, options);
@@ -360,16 +362,37 @@
         continue;
       }
 
-      while (scopes.length) {
-        translations = translations[scopes.shift()];
+      if (this.isSet(options.count)) {
+        while (scopes.length) {
+          translations = translations[scopes.shift()];
 
-        if (translations === undefined || translations === null) {
-          break;
+          if (scopes.length == 0 && isObject(translations)) {
+            var hasAllMessages = true;
+            keys = Object.keys(translations);
+            while (keys.length) {
+              key = keys.shift();
+              if (translations[key] === undefined || translations[key] === null) {
+                hasAllMessages = false;
+                break;
+              }
+            }
+            if (hasAllMessages) {
+              return translations;
+            }
+          }
         }
-      }
+      } else {
+        while (scopes.length) {
+          translations = translations[scopes.shift()];
 
-      if (translations !== undefined && translations !== null) {
-        return translations;
+          if (translations === undefined || translations === null) {
+            break;
+          }
+        }
+
+        if (translations !== undefined && translations !== null) {
+          return translations;
+        }
       }
     }
 

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -377,16 +377,35 @@
     }
   };
 
-  I18n.lookupForCount = function(scope, options) {
-    options = this.prepareOptions(options);
+  // lookup pluralization rule key into translations
+  I18n.pluralizationLookupWithoutFallback = function(count, locale, translations) {
+    var pluralizer = this.pluralization.get(locale)
+      , pluralizerKeys = pluralizer(count)
+      , pluralizerKey
+      , message;
 
+    if (isObject(translations)) {
+      while (pluralizerKeys.length) {
+        pluralizerKey = pluralizerKeys.shift();
+        if (this.isSet(translations[pluralizerKey])) {
+          message = translations[pluralizerKey];
+          break;
+        }
+      }
+    }
+
+    return message;
+  };
+
+  // Lookup dedicated to pluralization
+  I18n.pluralizationLookup = function(count, scope, options) {
+    options = this.prepareOptions(options);
     var locales = this.locales.get(options.locale).slice()
       , requestedLocale = locales[0]
       , locale
       , scopes
       , translations
-      , keys
-      , key
+      , message
     ;
     scope = this.getFullScope(scope, options);
 
@@ -398,31 +417,30 @@
       if (!translations) {
         continue;
       }
+
       while (scopes.length) {
         translations = translations[scopes.shift()];
-
         if (scopes.length == 0 && isObject(translations)) {
-          var hasAtLeastOneMessage = false;
-          keys = Object.keys(translations);
-          while (keys.length) {
-            key = keys.shift();
-            if (translations[key] !== undefined && translations[key] !== null) {
-              hasAtLeastOneMessage = true;
-              break;
-            }
-          }
-          if (hasAtLeastOneMessage) {
-            return translations;
-          }
+          message = this.pluralizationLookupWithoutFallback(count, locale, translations);
         }
+      }
+      if (message != null && message != undefined) {
+        break;
       }
     }
 
-    if (this.isSet(options.defaultValue)) {
-      return options.defaultValue;
+    if (message == null || message == undefined) {
+      if (this.isSet(options.defaultValue)) {
+        if (isObject(options.defaultValue)) {
+          message = this.pluralizationLookupWithoutFallback(count, options.locale, options.defaultValue);
+        } else {
+          message = options.defaultValue;
+        }
+        translations = options.defaultValue;
+      }
     }
 
-    return translations;
+    return { message: message, translations: translations };
   };
 
   // Rails changed the way the meridian is stored.
@@ -575,32 +593,20 @@
   // which will be retrieved from `options`.
   I18n.pluralize = function(count, scope, options) {
     options = this.prepareOptions(options);
-    var translations, pluralizer, keys, key, message;
+    var pluralizer, message, result;
 
-    translations = this.lookupForCount(scope, options);
-
-    if (!translations) {
+    result = this.pluralizationLookup(count, scope, options);
+    if (result.translations == undefined || result.translations == null) {
       return this.missingTranslation(scope, options);
-    }
-
-    pluralizer = this.pluralization.get(options.locale);
-    keys = pluralizer(count);
-
-    while (keys.length) {
-      key = keys.shift();
-
-      if (this.isSet(translations[key])) {
-        message = translations[key];
-        break;
-      }
     }
 
     options.count = String(count);
 
-    if (message != undefined) {
-      return this.interpolate(message, options);
+    if (result.message != undefined && result.message != null) {
+      return this.interpolate(result.message, options);
     }
     else {
+      pluralizer = this.pluralization.get(options.locale);
       return this.missingTranslation(scope + '.' + pluralizer(count)[0], options);
     }
   };

--- a/spec/js/pluralization.spec.js
+++ b/spec/js/pluralization.spec.js
@@ -126,4 +126,72 @@ describe("Pluralization", function(){
     expect(I18n.p(1, "inbox", { count: 1 })).toEqual("You have 1 message");
     expect(I18n.p(5, "inbox", { count: 5 })).toEqual("You have 5 messages");
   });
+
+  it("fallback to default locale when I18n.fallbacks is enabled", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["pt-BR"].inbox= {
+        one: "Você tem uma mensagem"
+      , other: null
+      , zero: "Você não tem nenhuma mensagem"
+    };
+    expect(I18n.p(0, "inbox", { count: 0 })).toEqual("Você não tem nenhuma mensagem");
+    expect(I18n.p(1, "inbox", { count: 1 })).toEqual("Você tem uma mensagem");
+    expect(I18n.p(5, "inbox", { count: 5 })).toEqual('You have 5 messages');
+  });
+
+  it("fallback to 'other' scope", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["pt-BR"].inbox= {
+        one: "Você tem uma mensagem"
+      , other: "Você tem {{count}} mensagens"
+      , zero: null
+    }
+    expect(I18n.p(0, "inbox", { count: 0 })).toEqual("Você tem 0 mensagens");
+    expect(I18n.p(1, "inbox", { count: 1 })).toEqual("Você tem uma mensagem");
+    expect(I18n.p(5, "inbox", { count: 5 })).toEqual("Você tem 5 mensagens");
+  });
+
+  it("fallback to defaulValue when defaultValue is string", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["en"]["inbox"]["zero"]  = null;
+    I18n.translations["en"]["inbox"]["one"]   = null;
+    I18n.translations["en"]["inbox"]["other"] = null;
+    I18n.translations["pt-BR"].inbox= {
+        one: "Você tem uma mensagem"
+      , other: null
+      , zero: null
+    }
+    options = {
+      defaultValue: "default message"
+    };
+    expect(I18n.p(0, "inbox", options)).toEqual("default message");
+    expect(I18n.p(1, "inbox", options)).toEqual("Você tem uma mensagem");
+    expect(I18n.p(5, "inbox", options)).toEqual("default message");
+  });
+
+  it("fallback to defaulValue when defaultValue is an object", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["en"]["inbox"]["zero"]  = null;
+    I18n.translations["en"]["inbox"]["one"]   = null;
+    I18n.translations["en"]["inbox"]["other"] = null;
+    I18n.translations["pt-BR"].inbox= {
+        one: "Você tem uma mensagem"
+      , other: null
+      , zero: null
+    }
+    options = {
+      defaultValue: {
+        zero: "default message for no message"
+        , one: "default message for 1 message"
+        , other: "default message for {{count}} messages"
+      }
+    };
+    expect(I18n.p(0, "inbox", options)).toEqual("default message for no message");
+    expect(I18n.p(1, "inbox", options)).toEqual("Você tem uma mensagem");
+    expect(I18n.p(5, "inbox", options)).toEqual("default message for 5 messages");
+  });
 });

--- a/spec/js/pluralization.spec.js
+++ b/spec/js/pluralization.spec.js
@@ -113,4 +113,17 @@ describe("Pluralization", function(){
     expect(I18n.p(1, "inbox", options)).toEqual("You have 1 message");
     expect(I18n.p(5, "inbox", options)).toEqual("You have 5 messages");
   });
+
+  it("fallback to default locale when I18n.fallbacks is enabled", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["pt-BR"].inbox= {
+        one: null
+      , other: null
+      , zero: null
+    };
+    expect(I18n.p(0, "inbox", { count: 0 })).toEqual("You have no messages");
+    expect(I18n.p(1, "inbox", { count: 1 })).toEqual("You have 1 message");
+    expect(I18n.p(5, "inbox", { count: 5 })).toEqual("You have 5 messages");
+  });
 });


### PR DESCRIPTION
When fallbacks activated, Pluralization won't work :

```javascript
I18n.fallbacks = "en";
I18n.locale = "en";
I18n.t("inbox.counting"); // { zero: "No message", one: "You a message", other: "You have %{count} messages"}
I18n.t("inbox.counting", {count: 10}); // You have 10 messages

I18n.locale = "fr";
I18n.t("inbox.counting", {count: 10}); // [missing "fr.inbox.counting.other" ]
// Expect english fallback : You have 10 messages
```


