### PR TITLE
BugFix : I18n pluralization missing subtree

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -420,7 +420,10 @@
 
       while (scopes.length) {
         translations = translations[scopes.shift()];
-        if (scopes.length == 0 && isObject(translations)) {
+        if (!isObject(translations)) {
+          break;
+        }
+        if (scopes.length == 0) {
           message = this.pluralizationLookupWithoutFallback(count, locale, translations);
         }
       }

--- a/spec/js/pluralization.spec.js
+++ b/spec/js/pluralization.spec.js
@@ -194,4 +194,18 @@ describe("Pluralization", function(){
     expect(I18n.p(1, "inbox", options)).toEqual("Você tem uma mensagem");
     expect(I18n.p(5, "inbox", options)).toEqual("default message for 5 messages");
   });
+
+  it("fallback to default locale when I18n.fallbacks is enabled and no translations in sub scope", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["en"]["mailbox"] = {
+      inbox: I18n.translations["en"].inbox
+    }
+
+    expect(I18n.translations["pt-BR"]["mailbox"]).toEqual(undefined);
+    expect(I18n.p(0, "mailbox.inbox", { count: 0 })).toEqual("You have no messages");
+    expect(I18n.p(1, "mailbox.inbox", { count: 1 })).toEqual("You have 1 message");
+    expect(I18n.p(5, "mailbox.inbox", { count: 5 })).toEqual("You have 5 messages");
+  });
+
 });


### PR DESCRIPTION
```yaml
en:
  mailbox:
    inbox:
      zero: ...
      one: ..
      other: ..
```
and

```js
>> I18n.translations["pt-BR"]["mailbox"]
undefined
```

Generate bug

```
>> I18n.fallbacks = "en";
>> I18n.locale = "pt-BR";
>> I18n.t("mailbox.inbox", { count: 2 });
TypeError: translations is undefined i18n.js (ligne 422, col. 37)
```