### PR TITLE
Fix #437 make defaultValue works on plural translation

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -525,6 +525,7 @@
   I18n.translate = function(scope, options) {
     options = this.prepareOptions(options);
 
+    var copiedOptions = this.prepareOptions(options);
     var translationOptions = this.createTranslationOptions(scope, options);
 
     var translation;
@@ -550,7 +551,7 @@
     if (typeof(translation) === "string") {
       translation = this.interpolate(translation, options);
     } else if (isObject(translation) && this.isSet(options.count)) {
-      translation = this.pluralize(options.count, scope, options);
+      translation = this.pluralize(options.count, scope, copiedOptions);
     }
 
     return translation;

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -152,6 +152,11 @@ describe("Translate", function(){
     expect(actual).toEqual("Warning!");
   });
 
+  it("uses default value for plural translation", function(){
+    actual = I18n.t("message", {defaultValue: { one: '%{count} message', other: '%{count} messages'}, count: 1});
+    expect(actual).toEqual("1 message");
+  });
+
   it("uses default value for unknown locale", function(){
     I18n.locale = "fr";
     actual = I18n.t("warning", {defaultValue: "Warning!"});


### PR DESCRIPTION
Make
```js
I18n.t("message", { defaultValue: { one: '%{count} message', other: '%{count} messages' }, count: 1 })
```
return 
```
   1 message
```