### PR TITLE
Fix UMD pattern so the global/root won’t be undefined

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -12,19 +12,23 @@
 // See tests for specific formatting like numbers and dates.
 //
 
-;(function(factory) {
-  if (typeof module !== 'undefined' && module.exports) {
-    // Node/CommonJS
-    module.exports = factory(this);
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    var global=this;
-    define('i18n', function(){ return factory(global);});
+// Using UMD pattern from
+// https://github.com/umdjs/umd#regular-module
+// `returnExports.js` version
+;(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define("i18n", function(){ return factory(root);});
+  } else if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(root);
   } else {
-    // Browser globals
-    this.I18n = factory(this);
+    // Browser globals (root is window)
+    root.I18n = factory(root);
   }
-}(function(global) {
+}(this, function(global) {
   "use strict";
 
   // Use previously defined object if exists in current scope

--- a/app/assets/javascripts/i18n/filtered.js.erb
+++ b/app/assets/javascripts/i18n/filtered.js.erb
@@ -1,17 +1,22 @@
 <%# encoding: utf-8 %>
 
-;(function(factory) {
-  if (typeof module !== 'undefined' && module.exports) {
-    // Node/CommonJS
-    factory(require('i18n'));
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    define(['i18n'], factory);
+// Using UMD pattern from
+// https://github.com/umdjs/umd#regular-module
+// `returnExports.js` version
+;(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(["i18n"], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    factory(require("i18n"));
   } else {
-    // Browser globals
-    factory(this.I18n);
+    // Browser globals (root is window)
+    factory(root.I18n);
   }
-}(function(I18n) {
+}(this, function(I18n) {
   "use strict";
 
   I18n.translations = <%= I18n::JS.filtered_translations.to_json %>;


### PR DESCRIPTION
I have this issue of `this` being `undefined` 
when loading and running in normal browser

So I search for some UMD example and apply the one I found
Tested locally and works well 

I also inspected `this` vs `root` inside the `function (root, factory)` with `console.log`
The `root` is a `window` and `this` is `undefined`

I got the same issue with zeroclipboard but I replace it with clipboard.js

