### PR TITLE
Feature/lazy default message

### DIFF
--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -145,6 +145,17 @@ describe("Translate", function(){
       actual = I18n.t("foo", options);
       expect(actual).toEqual("Hello all!");
     });
+
+    it("uses default value with lazy evaluation", function () {
+      var options = {
+          defaults: [{scope: "bar"}]
+        , defaultValue: function(scope) {
+          return scope.toUpperCase();
+        }
+      };
+      actual = I18n.t("foo", options);
+      expect(actual).toEqual("FOO");
+    })
   });
 
   it("uses default value for simple translation", function(){


### PR DESCRIPTION
Hi,

This pull request add a lazy evaluation feature to default message in translation,

ex:

```
I18n.t('foo.bar', {
  defaultValue: function(scope) {
    return scope.toUpperCase()
  }
})
// FOO.BAR
```

Also do some refactor to clear out where to put the lazy evaluation logic.