### PR TITLE
Refactor/remove side effect and prepare options

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -321,7 +321,7 @@
   // This is used internally by some functions and should not be used as an
   // public API.
   I18n.lookup = function(scope, options) {
-    options = this.prepareOptions(options);
+    options = options || {}
 
     var locales = this.locales.get(options.locale).slice()
       , requestedLocale = locales[0]
@@ -381,7 +381,7 @@
 
   // Lookup dedicated to pluralization
   I18n.pluralizationLookup = function(count, scope, options) {
-    options = this.prepareOptions(options);
+    options = options || {}
     var locales = this.locales.get(options.locale).slice()
       , requestedLocale = locales[0]
       , locale
@@ -505,7 +505,7 @@
 
   // Translate the given scope with the provided options.
   I18n.translate = function(scope, options) {
-    options = this.prepareOptions(options);
+    options = options || {}
 
     var copiedOptions = this.prepareOptions(options);
     var translationOptions = this.createTranslationOptions(scope, options);
@@ -541,7 +541,7 @@
 
   // This function interpolates the all variables in the given message.
   I18n.interpolate = function(message, options) {
-    options = this.prepareOptions(options);
+    options = options || {}
     var matches = message.match(this.placeholder)
       , placeholder
       , value
@@ -960,7 +960,7 @@
   };
 
   I18n.getFullScope = function(scope, options) {
-    options = this.prepareOptions(options);
+    options = options || {}
 
     // Deal with the scope as an array.
     if (isArray(scope)) {

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -497,7 +497,6 @@
     // insert it in to the translation options as such.
     if (isSet(options.defaultValue)) {
       translationOptions.push({ message: options.defaultValue });
-      delete options.defaultValue;
     }
 
     return translationOptions;
@@ -507,16 +506,19 @@
   I18n.translate = function(scope, options) {
     options = options || {}
 
-    var copiedOptions = this.prepareOptions(options);
     var translationOptions = this.createTranslationOptions(scope, options);
 
     var translation;
+
+    var optionsWithoutDefault = this.prepareOptions(options)
+    delete optionsWithoutDefault.defaultValue
+
     // Iterate through the translation options until a translation
     // or message is found.
     var translationFound =
       translationOptions.some(function(translationOption) {
         if (isSet(translationOption.scope)) {
-          translation = this.lookup(translationOption.scope, options);
+          translation = this.lookup(translationOption.scope, optionsWithoutDefault);
         } else if (isSet(translationOption.message)) {
           translation = lazyEvaluate(translationOption.message, scope);
         }
@@ -533,7 +535,7 @@
     if (typeof(translation) === "string") {
       translation = this.interpolate(translation, options);
     } else if (isObject(translation) && isSet(options.count)) {
-      translation = this.pluralize(options.count, scope, copiedOptions);
+      translation = this.pluralize(options.count, scope, options);
     }
 
     return translation;
@@ -578,15 +580,13 @@
   // The pluralized translation may have other placeholders,
   // which will be retrieved from `options`.
   I18n.pluralize = function(count, scope, options) {
-    options = this.prepareOptions(options);
+    options = this.prepareOptions({count: String(count)}, options)
     var pluralizer, message, result;
 
     result = this.pluralizationLookup(count, scope, options);
     if (result.translations == undefined || result.translations == null) {
       return this.missingTranslation(scope, options);
     }
-
-    options.count = String(count);
 
     if (result.message != undefined && result.message != null) {
       return this.interpolate(result.message, options);

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -146,6 +146,15 @@ describe("Translate", function(){
       expect(actual).toEqual("Hello all!");
     });
 
+    it("uses default scope over default value if default scope is found", function() {
+      var options = {
+          defaults: [{scope: "hello"}]
+        , defaultValue: "Hello all!"
+      };
+      actual = I18n.t("foo", options);
+      expect(actual).toEqual("Hello World!");
+    })
+
     it("uses default value with lazy evaluation", function () {
       var options = {
           defaults: [{scope: "bar"}]


### PR DESCRIPTION
Remove the code that update `options`,

It makes the code harder to read because we need to consider the case that options.defaultMessage and options.count will change after function call.

And generally, keep object immutable is a better practice.