### PR TITLE
use immutable options when doing lookup

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -534,7 +534,7 @@
     var translationFound =
       translationOptions.some(function(translationOption) {
         if (this.isSet(translationOption.scope)) {
-          translation = this.lookup(translationOption.scope, options);
+          translation = this.lookup(translationOption.scope, copiedOptions);
         } else if (this.isSet(translationOption.message)) {
           translation = translationOption.message;
         }


### PR DESCRIPTION
Fixes issue where defaultValue option provided but not used in lookup
because of mutation in `createTranslationOptions`