### PR TITLE
Avoid writing files if we don't have to.

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -219,6 +219,9 @@ module I18n
         FileUtils.mkdir_p(export_i18n_js_dir_path)
 
         i18n_js_path = File.expand_path('../../../app/assets/javascripts/i18n.js', __FILE__)
+        destination_path = File.expand_path("i18n.js", export_i18n_js_dir_path)
+        return if File.exist?(destination_path) && File.identical?(i18n_js_path, destination_path)
+
         FileUtils.cp(i18n_js_path, export_i18n_js_dir_path)
       end
 

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -40,11 +40,15 @@ module I18n
 
       def write_file(_file = @file, _translations = @translations)
         FileUtils.mkdir_p File.dirname(_file)
+        contents = js_header
+        _translations.each do |locale, translations_for_locale|
+          contents << js_translations(locale, translations_for_locale)
+        end
+
+        return if File.exist?(_file) && File.read(_file) == contents
+
         File.open(_file, "w+") do |f|
-          f << js_header
-          _translations.each do |locale, translations_for_locale|
-            f << js_translations(locale, translations_for_locale)
-          end
+          f << contents
         end
       end
 


### PR DESCRIPTION
Writing files triggers other actions in anything watching those files - eg
rebuilding a webpack bundle. Normally this won't occur as i18n-js's caching
will determine that nothing needs to be done, but it can add up quickly
when running individual specs from the command line, where the cache
is reset on every load.