### PR TITLE
Replace File.identical with FileUtils.compare_file

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -220,7 +220,7 @@ module I18n
 
         i18n_js_path = File.expand_path('../../../app/assets/javascripts/i18n.js', __FILE__)
         destination_path = File.expand_path("i18n.js", export_i18n_js_dir_path)
-        return if File.exist?(destination_path) && File.identical?(i18n_js_path, destination_path)
+        return if File.exist?(destination_path) && FileUtils.compare_file(i18n_js_path, destination_path)
 
         FileUtils.cp(i18n_js_path, export_i18n_js_dir_path)
       end


### PR DESCRIPTION
File.identical? only tells you if it's the same actual file (eg, a symlink or hardlink), but returns false if two different files have the same contents.

I've confirmed this change works - I'd confirmed the original version with `.cmp` (alias for `compare_file`), but not with `.identical?`. 