### PR TITLE
Fix extend method when translations has array values

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -117,7 +117,7 @@
     var key, value;
     for (key in obj) if (obj.hasOwnProperty(key)) {
       value = obj[key];
-      if (isString(value) || isNumber(value) || isBoolean(value)) {
+      if (isString(value) || isNumber(value) || isBoolean(value) || isArray(value)) {
         dest[key] = value;
       } else {
         if (dest[key] == null) dest[key] = {};

--- a/spec/js/extend.spec.js
+++ b/spec/js/extend.spec.js
@@ -82,4 +82,27 @@ describe("Extend", function () {
 
     expect(I18n.extend(obj1, obj2)).toEqual(expected);
   });
+
+  it("should merge array values", function() {
+    var obj1 = {
+      array1: [1, 2]
+    },
+    obj2 = {
+      array2: [1, 2],
+      obj3: {
+        array3: [1, 2],
+        array4: [{obj4: 1}, 2]
+      }
+    },
+    expected = {
+      array1: [1, 2],
+      array2: [1, 2],
+      obj3: {
+        array3: [1, 2],
+        array4: [{obj4: 1}, 2]
+      }
+    }
+
+    expect(JSON.stringify(I18n.extend(obj1, obj2))).toEqual(JSON.stringify(expected));
+  });
 });


### PR DESCRIPTION
When `js_extend: true`, the arrays in `I18n.translations` are being transformed in objects. 

`I18n.extend({}, {array:[1, 2]})` results in an `array: {0: 1, 1: 2}`.

This pull fix this behavior.