### PR TITLE
Fix a bug when rails project has only Webpacker

### DIFF
--- a/lib/i18n/js/dependencies.rb
+++ b/lib/i18n/js/dependencies.rb
@@ -20,7 +20,7 @@ module I18n
           assets_pipeline_available =
             (rails3? || rails4? || rails5?) &&
             Rails.respond_to?(:application) &&
-            Rails.application.respond_to?(:assets)
+            Rails.application.config.respond_to?(:assets)
           rails3_assets_enabled =
             rails3? &&
             assets_pipeline_available &&


### PR DESCRIPTION
When a Rails app doesn't have Sprockets installed and it compiles the assets through Webpacker, the Gem fails.

![image](https://user-images.githubusercontent.com/2339362/35353034-0e37f9a8-012d-11e8-8475-03460a4f244a.png)

The reason is that the Gem is checking the presence of the pipeline with the `Rails.application.respond_to?(:assets)`, where it is always true even when there is no Sprockets in project. This pull fix that.