### PR TITLE
Add config file as a dependency of filtered translations

### DIFF
--- a/lib/i18n/js/engine.rb
+++ b/lib/i18n/js/engine.rb
@@ -60,6 +60,7 @@ module I18n
       def self.run(filename, source, context)
         if context.logical_path == "i18n/filtered"
           ::I18n.load_path.each { |path| context.depend_on(File.expand_path(path)) }
+          context.depend_on(File.expand_path(I18n::JS.config_file_path))
         end
 
         source


### PR DESCRIPTION
`i18n/filtered` should depend also on config file, because config determines
the set of keys in the generated JS file.