### PR TITLE
Configurable backend

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -28,6 +28,15 @@ module I18n
       @config_file_path = new_path
     end
 
+    # Allow using a different backend than the one globally configured
+    def self.backend
+      @backend ||= I18n.backend
+    end
+
+    def self.backend=(alternative_backend)
+      @backend = alternative_backend
+    end
+
     # Export translations to JavaScript, considering settings
     # from configuration file
     def self.export
@@ -161,7 +170,7 @@ module I18n
 
     # Initialize and return translations
     def self.translations
-      ::I18n.backend.instance_eval do
+      self.backend.instance_eval do
         init_translations unless initialized?
         # When activesupport is absent,
         # the core extension (`#slice`) from `i18n` gem will be used instead

--- a/lib/i18n/js/fallback_locales.rb
+++ b/lib/i18n/js/fallback_locales.rb
@@ -57,7 +57,7 @@ module I18n
       #
       #   Maybe this should be fixed within I18n.
       def using_i18n_fallbacks_module?
-        I18n.backend.class.included_modules.include?(I18n::Backend::Fallbacks)
+        I18n::JS.backend.class.included_modules.include?(I18n::Backend::Fallbacks)
       end
 
       def ensure_valid_fallbacks_as_array!

--- a/spec/ruby/i18n/js/fallback_locales_spec.rb
+++ b/spec/ruby/i18n/js/fallback_locales_spec.rb
@@ -55,10 +55,10 @@ describe I18n::JS::FallbackLocales do
       let(:backend_with_fallbacks) { backend_class_with_fallbacks.new }
 
       before do
-        I18n.backend = backend_with_fallbacks
+        I18n::JS.backend = backend_with_fallbacks
         I18n.fallbacks[:fr] = [:de, :en]
       end
-      after { I18n.backend = I18n::Backend::Simple.new }
+      after { I18n::JS.backend = I18n::Backend::Simple.new }
 
       context "given true as fallbacks" do
         let(:fallbacks) { true }

--- a/spec/ruby/i18n/js_spec.rb
+++ b/spec/ruby/i18n/js_spec.rb
@@ -313,10 +313,10 @@ EOS
       let!(:old_backebad) { I18n.backend }
 
       before do
-        I18n.backend = backend_with_fallbacks
+        I18n::JS.backend = backend_with_fallbacks
         I18n.fallbacks[:fr] = [:de, :en]
       end
-      after { I18n.backend = old_backebad }
+      after { I18n::JS.backend = old_backebad }
 
       it "exports with defined locale as fallback when enabled" do
         set_config "js_file_per_locale_with_fallbacks_enabled.yml"


### PR DESCRIPTION
Hi,
this PR addresses issues #428 and #344.
Only supporting the Simple backend to generate `translations.js` makes sense to me, since a dynamic backend like a database or something custom would raise questions about when to re-build the asset.

If you, like us, use a Chain backend with some custom stuff followed by the Simple backend and are fine with the custom stuff not being present in JS, then you can use the monkey-patch from #428.

This PR would allow to set `I18n::JS.backend = I18n::Backend::Simple.new` in an initializer, without having to monkey-patch the entire `I18n::JS.translate` method.

Quickly grepping through the project for `backend` revealed [this other use of it](https://github.com/fnando/i18n-js/blob/77e0eac361cf5e1f0cb02b2f18936f714aada92e/lib/i18n/js/fallback_locales.rb#L60), which might break if just monkey-patching `I18n::JS.translate`. I think this is a good reason, to allow this to be set from the outside.

Please let me know, what you think of this idea. If you like it, I would be happy to update README, and CHANGELOG and add/update specs. I'm not 100% sure how this might conflict with other features like `available_locales`.