### PR TITLE
Add json only feature for file exports/nodejs imports

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -187,6 +187,13 @@ module I18n
       fallbacks != false
     end
 
+    def self.json_only
+      config.fetch(:json_only) do
+        # default value
+        false
+      end
+    end
+
     def self.fallbacks
       config.fetch(:fallbacks) do
         # default value
@@ -215,6 +222,7 @@ module I18n
       segment_options = Private::HashWithSymbolKeys.new({
         js_extend: js_extend,
         sort_translation_keys: sort_translation_keys?,
+        json_only: json_only
       }).freeze
       segment_options.merge(options.slice(*Segment::OPTIONS))
     end

--- a/lib/i18n/js/errors.rb
+++ b/lib/i18n/js/errors.rb
@@ -1,0 +1,9 @@
+module I18n
+  module JS
+    class JsonOnlyLocaleRequiredError < StandardError
+      def message
+        'The json_only option requires %{locale} in the file name.'
+      end
+    end
+  end
+end

--- a/spec/fixtures/json_only.yml
+++ b/spec/fixtures/json_only.yml
@@ -1,0 +1,8 @@
+fallbacks: false
+json_only: true
+
+translations:
+  - file: "tmp/i18n-js/json_only.%{locale}.js"
+    only:
+      - "*.date.formats.*"
+      - "*.number.currency.*"


### PR DESCRIPTION
New config key: 
`json_only default: false`


```yaml
#config/i18n-js.yml
fallbacks: false
json_only: true

translations:
  - file: "tmp/i18n-js/%{locale}.js"
```

outputs:
```
{"en":{"test":"Test"}}
```

instead of:
```
I18n.translations || (I18n.translations = {});
I18n.translations[\"en\"] = {"en":{"test":"Test"}};
```

This is so I can manually host the translation files behind a custom controller behind authentication using rails as an api only backend, but would be useful for anyone looking to host the files separately in an automated way.