### PR TITLE
* Add support for option `separator` (key/scope separator) to translate methods

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -402,7 +402,7 @@
 
     while (locales.length) {
       locale = locales.shift();
-      scopes = fullScope.split(this.defaultSeparator);
+      scopes = fullScope.split(options.separator || this.defaultSeparator);
       translations = this.translations[locale];
 
       if (!translations) {
@@ -459,7 +459,7 @@
 
     while (locales.length) {
       locale = locales.shift();
-      scopes = scope.split(this.defaultSeparator);
+      scopes = scope.split(options.separator || this.defaultSeparator);
       translations = this.translations[locale];
 
       if (!translations) {
@@ -685,7 +685,7 @@
 
     var localeForTranslation = (options != null && options.locale != null) ? options.locale : this.currentLocale();
     var fullScope           = this.getFullScope(scope, options);
-    var fullScopeWithLocale = [localeForTranslation, fullScope].join(this.defaultSeparator);
+    var fullScopeWithLocale = [localeForTranslation, fullScope].join(options.separator || this.defaultSeparator);
 
     return '[missing "' + fullScopeWithLocale + '" translation]';
   };
@@ -1053,7 +1053,7 @@
 
     // Deal with the scope as an array.
     if (isArray(scope)) {
-      scope = scope.join(this.defaultSeparator);
+      scope = scope.join(options.separator || this.defaultSeparator);
     }
 
     // Deal with the scope option provided through the second argument.
@@ -1061,7 +1061,7 @@
     //    I18n.t('hello', {scope: 'greetings'});
     //
     if (options.scope) {
-      scope = [options.scope, scope].join(this.defaultSeparator);
+      scope = [options.scope, scope].join(options.separator || this.defaultSeparator);
     }
 
     return scope;

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -296,4 +296,9 @@ describe("Translate", function(){
       {foo: "bar"}
     ]);
   });
+
+
+  it("returns value with key containing dot but different separator specified", function() {
+    expect(I18n.t(["A implies B means something."], {scope: "sentences_with_dots", separator: "|"})).toEqual("A implies B means that when A is true, B must be true.");
+  });
 });

--- a/spec/js/translations.js
+++ b/spec/js/translations.js
@@ -67,7 +67,11 @@
         {foo: "bar"}
       ]
 
-      , null_key: null
+      , null_key: null,
+
+      sentences_with_dots: {
+          "A implies B means something.": "A implies B means that when A is true, B must be true."
+      }
     };
 
     Translations["en-US"] = {


### PR DESCRIPTION
Fixes
#540 #441 #424

There is global option `defaultSeparator` already but lacks option when calling `translate`