### PR TITLE
add basic support for duration to strftime(), toTime()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Nothing
+- optional "durationFlag" to strftime(), toTime() functions
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -592,6 +592,14 @@ I18n.toTime("date.formats.short", date);
 I18n.strftime(date, "%d/%m/%Y");
 ```
 
+We have some basic support for formatting durations too.
+
+```javascript
+var duration = new Date(60000); // 1 minute
+I18n.strftime("date.formats.durationHMM", duration, true);
+I18n.strftime(duration, "%-H:%M", true);
+```
+
 The accepted formats for `I18n.strftime` are:
 
     %a     - The abbreviated weekday name (Sun)

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -914,9 +914,10 @@
   //     %Y     - Year with century
   //     %z/%Z  - Timezone offset (+0545)
   //
-  I18n.strftime = function(date, format) {
+  I18n.strftime = function(date, format, durationFlag) {
     var options = this.lookup("date")
       , meridianOptions = I18n.meridian()
+      , duration = !!durationFlag
     ;
 
     if (!options) {
@@ -929,15 +930,15 @@
       throw new Error('I18n.strftime() requires a valid date object, but received an invalid date.');
     }
 
-    var weekDay = date.getDay()
-      , day = date.getDate()
-      , year = date.getFullYear()
-      , month = date.getMonth() + 1
-      , hour = date.getHours()
+    var weekDay = duration ? date.getUTCDay() : date.getDay()
+      , day = duration ? date.getUTCDate() : date.getDate()
+      , year = duration ? date.getUTCFullYear() : date.getFullYear()
+      , month = duration ? date.getUTCMonth() + 1 : date.getMonth() + 1
+      , hour = duration ? date.getUTCHours() : date.getHours()
       , hour12 = hour
       , meridian = hour > 11 ? 1 : 0
-      , secs = date.getSeconds()
-      , mins = date.getMinutes()
+      , secs = duration ? date.getUTCSeconds() : date.getSeconds()
+      , mins = duration ? date.getUTCMinutes() : date.getMinutes()
       , offset = date.getTimezoneOffset()
       , absOffsetHours = Math.floor(Math.abs(offset / 60))
       , absOffsetMinutes = Math.abs(offset) - (absOffsetHours * 60)
@@ -983,7 +984,7 @@
   };
 
   // Convert the given dateString into a formatted date.
-  I18n.toTime = function(scope, dateString) {
+  I18n.toTime = function(scope, dateString, durationFlag) {
     var date = this.parseDate(dateString)
       , format = this.lookup(scope)
     ;
@@ -1002,7 +1003,7 @@
       return date_string;
     }
 
-    return this.strftime(date, format);
+    return this.strftime(date, format, durationFlag);
   };
 
   // Convert a number into a formatted percentage value.

--- a/spec/js/duration.spec.js
+++ b/spec/js/duration.spec.js
@@ -1,0 +1,26 @@
+var I18n = require("../../app/assets/javascripts/i18n");
+
+describe("Duration", function(){
+  var actual, expected;
+
+  beforeEach(function() {
+    I18n.reset();
+  });
+
+  it("doesn't add clients timezone", function() {
+    // 1 hour 5 minutes = 3900 seconds
+    var duration = new Date(3900 * 1000);
+
+    // 24-hour
+    expect(I18n.strftime(duration, "%-H", true)).toEqual("1");
+    expect(I18n.strftime(duration, "%H", true)).toEqual("01");
+
+    // 12-hour
+    expect(I18n.strftime(duration, "%-I", true)).toEqual("1");
+    expect(I18n.strftime(duration, "%I", true)).toEqual("01");
+
+    // minutes
+    expect(I18n.strftime(duration, "%-M", true)).toEqual("5");
+    expect(I18n.strftime(duration, "%M", true)).toEqual("05");
+  });
+});

--- a/spec/js/specs_requirejs.html
+++ b/spec/js/specs_requirejs.html
@@ -22,6 +22,7 @@
                 "./currency.spec.js",
                 "./current_locale.spec.js",
                 "./dates.spec.js",
+                "./duration.spec.js",
                 "./defaults.spec.js",
                 "./interpolation.spec.js",
                 "./localization.spec.js",


### PR DESCRIPTION
Hi

first of all, thanks for this library, even so I'm no Ruby developer, just plain JS. Thx much anyway :)

I encountered usage that hasn't been covered yet, formatting of time intervals, no matter if positive or negative. There was always client's local timezone in play, so it was kind of...inaccurate... This patch presents optional `durationFlag` which prints `Date` objects is as, w/o timezone. Maybe it can be useful for others too.

BR
Arnost

P.S. because I can't find any code style guides or such, I have done usual "docs" and "tests" stuff