### PR TITLE
fix: available_locales to come from backend instead of I18n

### DIFF
--- a/lib/i18n/js.rb
+++ b/lib/i18n/js.rb
@@ -78,7 +78,7 @@ module I18n
 
     # deep_merge! given result with result for fallback locale
     def self.merge_with_fallbacks!(result)
-      I18n.available_locales.each do |locale|
+      backend.available_locales.each do |locale|
         fallback_locales = FallbackLocales.new(fallbacks, locale)
         fallback_locales.each do |fallback_locale|
           # `result[fallback_locale]` could be missing


### PR DESCRIPTION
This resolves an issue, in which available_locales for fallbacks are different than the ones provided in the custom backend. The change will allow the existing behaviour (with SimpleBackend) to remain the same but fixes the value returned when the custom backend is being used.

Co-Authored-By: @jfhinchcliffe