### PR TITLE
Add ability to import libraries on top of the translations file in an es6 way

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,17 +247,19 @@ MyNamespace.translations || (MyNamespace.translations = {});
 MyNamespace.translations["en"] = { ... }
 ```
 
-### Import I18n library in the translations file
 
-Setting the `import: 'i18n-js'` option will add `import I18n from 'i18n-js';`. The name of the package to import can be changed.
+### Adding a line at the beggining of the translations file (useful for imports)
+
+Setting the `prefix: "import I18n from 'i18n-js';\n"` option will add the line at the beggining of the resultant translation file.
 This can be useful to use this gem with the [i18n-js](https://www.npmjs.com/package/i18n-js) npm package, which is quite useful to use it with webpack.
+The user should provide the semi-colon and the newline character if needed.
 
 For example:
 
 ```yaml
 translations:
 - file: "public/javascripts/i18n/translations.js"
-  import: 'i18n-js'
+  prefix: "import I18n from 'i18n-js';\n"
 ```
 
 will create:
@@ -265,7 +267,7 @@ will create:
 ```
 import I18n from 'i18n-js';
 I18n.translations || (I18n.translations = {});
-```
+
 
 #### Pretty Print
 
@@ -301,7 +303,8 @@ by hand or using your favorite programming language. More info below.
 #### Via NPM with webpack and CommonJS
 
 
-Add the following line to your package.json dependencies where version is the version you want
+Add the following line to your package.json dependencies  
+where version is the version you want  
 ```javascript
 "i18n-js": "{version_constraint}"
 
@@ -640,8 +643,8 @@ The accepted formats for `I18n.strftime` are:
 Check out `spec/*.spec.js` files for more examples!
 
 #### Using pluralization and number formatting together
-Sometimes you might want to display translation with formatted number, like adding thousand delimiters to displayed number
-You can do this:
+Sometimes you might want to display translation with formatted number, like adding thousand delimiters to displayed number  
+You can do this:  
 ```json
 {
   "en": {
@@ -812,7 +815,7 @@ Due to the design of `sprockets`:
 This means that new locale files will not be detected, and so they will not trigger a i18n-js refresh. There are a few approaches to work around this:
 
 1. You can force i18n-js to update its translations by completely clearing the assets cache. Use one of the following:
-
+  
 ```bash
 $ rake assets:clobber
 # Or, with older versions of Rails:
@@ -836,7 +839,7 @@ or similar commands.  If you are precompiling assets on the target machine(s), c
 ### Translations in JS are not updated when Sprockets not loaded before this gem
 
 The "rails engine" declaration will try to detect existence of "sprockets" before adding the initailizer
-If sprockets is loaded after this gem, the preprocessor for
+If sprockets is loaded after this gem, the preprocessor for 
 making JS translations file cache to depend on content of locale files will not be hooked.
 So ensure sprockets is loaded before this gem like moving entry of sprockets in Gemfile or adding "require" statements for sprockets somewhere.
 
@@ -844,7 +847,7 @@ So ensure sprockets is loaded before this gem like moving entry of sprockets in 
 
 ### JS `I18n.toCurrency` & `I18n.toNumber` cannot handle large integers
 
-The above methods use `toFixed` and it only supports 53 bit integers.
+The above methods use `toFixed` and it only supports 53 bit integers.  
 Ref: http://2ality.com/2012/07/large-integers.html
 
 Feel free to find & discuss possible solution(s) at issue [#511](https://github.com/fnando/i18n-js/issues/511)

--- a/README.md
+++ b/README.md
@@ -247,6 +247,25 @@ MyNamespace.translations || (MyNamespace.translations = {});
 MyNamespace.translations["en"] = { ... }
 ```
 
+### Import I18n library in the translations file
+
+Setting the `import: 'i18n-js'` option will add `import I18n from 'i18n-js';`. The name of the package to import can be changed.
+This can be useful to use this gem with the [i18n-js](https://www.npmjs.com/package/i18n-js) npm package, which is quite useful to use it with webpack.
+
+For example:
+
+```yaml
+translations:
+- file: "public/javascripts/i18n/translations.js"
+  import: 'i18n-js'
+```
+
+will create:
+
+```
+import I18n from 'i18n-js';
+I18n.translations || (I18n.translations = {});
+```
 
 #### Pretty Print
 
@@ -282,8 +301,7 @@ by hand or using your favorite programming language. More info below.
 #### Via NPM with webpack and CommonJS
 
 
-Add the following line to your package.json dependencies  
-where version is the version you want  
+Add the following line to your package.json dependencies where version is the version you want
 ```javascript
 "i18n-js": "{version_constraint}"
 
@@ -622,8 +640,8 @@ The accepted formats for `I18n.strftime` are:
 Check out `spec/*.spec.js` files for more examples!
 
 #### Using pluralization and number formatting together
-Sometimes you might want to display translation with formatted number, like adding thousand delimiters to displayed number  
-You can do this:  
+Sometimes you might want to display translation with formatted number, like adding thousand delimiters to displayed number
+You can do this:
 ```json
 {
   "en": {
@@ -794,7 +812,7 @@ Due to the design of `sprockets`:
 This means that new locale files will not be detected, and so they will not trigger a i18n-js refresh. There are a few approaches to work around this:
 
 1. You can force i18n-js to update its translations by completely clearing the assets cache. Use one of the following:
-  
+
 ```bash
 $ rake assets:clobber
 # Or, with older versions of Rails:
@@ -818,7 +836,7 @@ or similar commands.  If you are precompiling assets on the target machine(s), c
 ### Translations in JS are not updated when Sprockets not loaded before this gem
 
 The "rails engine" declaration will try to detect existence of "sprockets" before adding the initailizer
-If sprockets is loaded after this gem, the preprocessor for 
+If sprockets is loaded after this gem, the preprocessor for
 making JS translations file cache to depend on content of locale files will not be hooked.
 So ensure sprockets is loaded before this gem like moving entry of sprockets in Gemfile or adding "require" statements for sprockets somewhere.
 
@@ -826,7 +844,7 @@ So ensure sprockets is loaded before this gem like moving entry of sprockets in 
 
 ### JS `I18n.toCurrency` & `I18n.toNumber` cannot handle large integers
 
-The above methods use `toFixed` and it only supports 53 bit integers.  
+The above methods use `toFixed` and it only supports 53 bit integers.
 Ref: http://2ality.com/2012/07/large-integers.html
 
 Feel free to find & discuss possible solution(s) at issue [#511](https://github.com/fnando/i18n-js/issues/511)

--- a/lib/i18n/js/formatters/base.rb
+++ b/lib/i18n/js/formatters/base.rb
@@ -2,10 +2,11 @@ module I18n
   module JS
     module Formatters
       class Base
-        def initialize(js_extend: false, namespace: nil, pretty_print: false)
+        def initialize(js_extend: false, namespace: nil, pretty_print: false, import: nil)
           @js_extend    = js_extend
           @namespace    = namespace
           @pretty_print = pretty_print
+          @import = import
         end
 
         protected

--- a/lib/i18n/js/formatters/base.rb
+++ b/lib/i18n/js/formatters/base.rb
@@ -2,11 +2,11 @@ module I18n
   module JS
     module Formatters
       class Base
-        def initialize(js_extend: false, namespace: nil, pretty_print: false, import: nil)
+        def initialize(js_extend: false, namespace: nil, pretty_print: false, prefix: nil)
           @js_extend    = js_extend
           @namespace    = namespace
           @pretty_print = pretty_print
-          @import = import
+          @prefix = prefix
         end
 
         protected

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -15,7 +15,8 @@ module I18n
         protected
 
         def header
-          %(#{@namespace}.translations || (#{@namespace}.translations = {});\n)
+          text = @import ? %(import I18n from '#{@import}';\n) : ''
+          text + %(#{@namespace}.translations || (#{@namespace}.translations = {});\n)
         end
 
         def line(locale, translations)

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -15,7 +15,7 @@ module I18n
         protected
 
         def header
-          text = @import ? %(import I18n from '#{@import}';\n) : ''
+          text = @prefix || ''
           text + %(#{@namespace}.translations || (#{@namespace}.translations = {});\n)
         end
 

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -7,7 +7,7 @@ module I18n
 
     # Class which enscapulates a translations hash and outputs a single JSON translation file
     class Segment
-      OPTIONS = [:namespace, :pretty_print, :js_extend, :import, :sort_translation_keys, :json_only].freeze
+      OPTIONS = [:namespace, :pretty_print, :js_extend, :prefix, :sort_translation_keys, :json_only].freeze
       LOCALE_INTERPOLATOR = /%\{locale\}/
 
       attr_reader *([:file, :translations] | OPTIONS)
@@ -24,7 +24,7 @@ module I18n
         @namespace    = options[:namespace] || 'I18n'
         @pretty_print = !!options[:pretty_print]
         @js_extend    = options.key?(:js_extend) ? !!options[:js_extend] : true
-        @import       = options.key?(:import) ? options[:import] : nil
+        @prefix       = options.key?(:prefix) ? options[:prefix] : nil
         @sort_translation_keys = options.key?(:sort_translation_keys) ? !!options[:sort_translation_keys] : true
         @json_only = options.key?(:json_only) ? !!options[:json_only] : false
       end
@@ -70,7 +70,7 @@ module I18n
         { js_extend: @js_extend,
           namespace: @namespace,
           pretty_print: @pretty_print,
-          import: @import }
+          prefix: @prefix }
       end
     end
   end

--- a/lib/i18n/js/segment.rb
+++ b/lib/i18n/js/segment.rb
@@ -7,7 +7,7 @@ module I18n
 
     # Class which enscapulates a translations hash and outputs a single JSON translation file
     class Segment
-      OPTIONS = [:namespace, :pretty_print, :js_extend, :sort_translation_keys, :json_only].freeze
+      OPTIONS = [:namespace, :pretty_print, :js_extend, :import, :sort_translation_keys, :json_only].freeze
       LOCALE_INTERPOLATOR = /%\{locale\}/
 
       attr_reader *([:file, :translations] | OPTIONS)
@@ -24,6 +24,7 @@ module I18n
         @namespace    = options[:namespace] || 'I18n'
         @pretty_print = !!options[:pretty_print]
         @js_extend    = options.key?(:js_extend) ? !!options[:js_extend] : true
+        @import       = options.key?(:import) ? options[:import] : nil
         @sort_translation_keys = options.key?(:sort_translation_keys) ? !!options[:sort_translation_keys] : true
         @json_only = options.key?(:json_only) ? !!options[:json_only] : false
       end
@@ -68,7 +69,8 @@ module I18n
       def formatter_options
         { js_extend: @js_extend,
           namespace: @namespace,
-          pretty_print: @pretty_print }
+          pretty_print: @pretty_print,
+          import: @import }
       end
     end
   end

--- a/spec/fixtures/js_file_with_namespace_import_and_pretty_print.yml
+++ b/spec/fixtures/js_file_with_namespace_import_and_pretty_print.yml
@@ -5,3 +5,4 @@ translations:
     only: '*'
     namespace: "Foo"
     pretty_print: true
+    import: 'random-library'

--- a/spec/fixtures/js_file_with_namespace_prefix_and_pretty_print.yml
+++ b/spec/fixtures/js_file_with_namespace_prefix_and_pretty_print.yml
@@ -5,4 +5,4 @@ translations:
     only: '*'
     namespace: "Foo"
     pretty_print: true
-    import: 'random-library'
+    prefix: "import random from 'random-library';\n"

--- a/spec/ruby/i18n/js_spec.rb
+++ b/spec/ruby/i18n/js_spec.rb
@@ -351,11 +351,11 @@ EOS
     end
   end
 
-  context "namespace and pretty_print options" do
+  context "namespace, import and pretty_print options" do
 
     before do
       stub_const('I18n::JS::DEFAULT_EXPORT_DIR_PATH', temp_path)
-      set_config "js_file_with_namespace_and_pretty_print.yml"
+      set_config "js_file_with_namespace_import_and_pretty_print.yml"
     end
 
     it "exports with defined locale as fallback when enabled" do
@@ -364,6 +364,7 @@ EOS
       output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "en.js"))
       expect(output).to match(/^#{
 <<EOS
+import I18n from 'random-library';
 Foo.translations || (Foo.translations = {});
 Foo.translations["en"] = {
   "number": {

--- a/spec/ruby/i18n/js_spec.rb
+++ b/spec/ruby/i18n/js_spec.rb
@@ -351,11 +351,11 @@ EOS
     end
   end
 
-  context "namespace, import and pretty_print options" do
+  context "namespace, prefix and pretty_print options" do
 
     before do
       stub_const('I18n::JS::DEFAULT_EXPORT_DIR_PATH', temp_path)
-      set_config "js_file_with_namespace_import_and_pretty_print.yml"
+      set_config "js_file_with_namespace_prefix_and_pretty_print.yml"
     end
 
     it "exports with defined locale as fallback when enabled" do
@@ -364,7 +364,7 @@ EOS
       output = File.read(File.join(I18n::JS.export_i18n_js_dir_path, "en.js"))
       expect(output).to match(/^#{
 <<EOS
-import I18n from 'random-library';
+import random from 'random-library';
 Foo.translations || (Foo.translations = {});
 Foo.translations["en"] = {
   "number": {


### PR DESCRIPTION
In order to use rails with webpack and the [i18n-js npm package](https://www.npmjs.com/package/i18n-js) all together, `import I18n from 'i18n-js';` should be added to the resultant `translations.js` file.

This PR allows an user to add the import programatically just adding the option in the `i18n-js.yml` file. 

Thanks @PikachuEXE for your package, I hope you find this option useful 😄 