### PR TITLE
added strftime format %k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Nothing
+- Support for `%k` strftime format to match Ruby strftime
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ The accepted formats for `I18n.strftime` are:
     %d     - Day of the month (01..31)
     %-d    - Day of the month (1..31)
     %H     - Hour of the day, 24-hour clock (00..23)
-    %-H    - Hour of the day, 24-hour clock (0..23)
+    %-H/%k - Hour of the day, 24-hour clock (0..23)
     %I     - Hour of the day, 12-hour clock (01..12)
     %-I/%l - Hour of the day, 12-hour clock (1..12)
     %m     - Month of the year (01..12)

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -897,7 +897,7 @@
   //     %d     - Day of the month (01..31)
   //     %-d    - Day of the month (1..31)
   //     %H     - Hour of the day, 24-hour clock (00..23)
-  //     %-H    - Hour of the day, 24-hour clock (0..23)
+  //     %-H/%k - Hour of the day, 24-hour clock (0..23)
   //     %I     - Hour of the day, 12-hour clock (01..12)
   //     %-I/%l - Hour of the day, 12-hour clock (1..12)
   //     %m     - Month of the year (01..12)
@@ -961,6 +961,7 @@
     format = format.replace("%-d", day);
     format = format.replace("%H", padding(hour));
     format = format.replace("%-H", hour);
+    format = format.replace("%k", hour);
     format = format.replace("%I", padding(hour12));
     format = format.replace("%-I", hour12);
     format = format.replace("%l", hour12);

--- a/spec/js/dates.spec.js
+++ b/spec/js/dates.spec.js
@@ -132,6 +132,7 @@ describe("Dates", function(){
 
     // 24-hour without padding
     expect(I18n.strftime(date, "%-H")).toEqual("7");
+    expect(I18n.strftime(date, "%k")).toEqual("7");
 
     // 12-hour without padding
     expect(I18n.strftime(date, "%-I")).toEqual("7");


### PR DESCRIPTION
We need %k format (24-hour clock, no padding) in our app to use the same formats in Rails code and in JS. It's just an alias for the existing %-H directive.

Doc and test are included.

Thanks for your work!