### PR TITLE
Allow callback for missing translations

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -189,6 +189,9 @@
     // Set missing translation behavior. 'message' will display a message
     // that the translation is missing, 'guess' will try to guess the string
     , missingBehaviour: 'message'
+    // Set a callback to be called with translations are missing. Can be used to
+    // report missing translations to exception tracking
+    , missingCallback: undefined
     // if you use missingBehaviour with 'message', but want to know that the
     // string is actually missing for testing purposes, you can prefix the
     // guessed string by setting the value here. By default, no prefix!
@@ -673,6 +676,14 @@
 
   // Return a missing translation message for the given parameters.
   I18n.missingTranslation = function(scope, options) {
+    var localeForTranslation = (options != null && options.locale != null) ? options.locale : this.currentLocale();
+    var fullScope           = this.getFullScope(scope, options);
+    var fullScopeWithLocale = [localeForTranslation, fullScope].join(this.defaultSeparator);
+
+    if (this.missingCallback) {
+      this.missingCallback(fullScopeWithLocale);
+    }
+
     //guess intended string
     if(this.missingBehaviour === 'guess'){
       //get only the last portion of the scope
@@ -682,10 +693,6 @@
           s.replace('_',' ').replace(/([a-z])([A-Z])/g,
           function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
     }
-
-    var localeForTranslation = (options != null && options.locale != null) ? options.locale : this.currentLocale();
-    var fullScope           = this.getFullScope(scope, options);
-    var fullScopeWithLocale = [localeForTranslation, fullScope].join(this.defaultSeparator);
 
     return '[missing "' + fullScopeWithLocale + '" translation]';
   };

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -67,6 +67,14 @@ describe("Translate", function(){
     expect(actual).toEqual(expected);
   });
 
+  it("calls the missing callback for missing translation when a callback is defined", function(){
+    var called = false;
+    callback = function() { called = true };
+    I18n.missingCallback = callback;
+    I18n.translate("monster", {scope: "greetings"});
+    expect(called).toBe(true);
+  });
+
   it("returns translation for single scope on a custom locale", function(){
     I18n.locale = "pt-BR";
     expect(I18n.translate("hello")).toEqual("Olá Mundo!");


### PR DESCRIPTION
Rails makes it possible to raise an exception for a missing translation,
which can be useful in development and test environments to spot
undefined translations. This change adds an optional user-definable callback
that can be invoked any time a translation is missing for translations called in JavaScript. It could be used in tests to identify undefined translations or in production environments to report missing translations to an exception tracking
service.

When defined, the missing translation callback does not replace the
existing guess/missing translation options, it's invoked in addition to
the existing placeholders.

Close #477.