### PR TITLE
Fixed: now all underscores replaces to spaces

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -679,7 +679,7 @@
       var s = scope.split('.').slice(-1)[0];
       //replace underscore with space && camelcase with space and lowercase letter
       return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
-          s.replace('_',' ').replace(/([a-z])([A-Z])/g,
+          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g,
           function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
     }
 

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -48,7 +48,7 @@ describe("Translate", function(){
 
   it("returns guessed translation if missingBehaviour is set to guess", function(){
     I18n.missingBehaviour = 'guess'
-    actual = I18n.translate("invalid.thisIsAutomaticallyGeneratedTranslation");
+    actual = I18n.translate("invalid.this_Is_AutomaticallyGeneratedTranslation");
     expected = 'this is automatically generated translation';
     expect(actual).toEqual(expected);
   });

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -48,7 +48,7 @@ describe("Translate", function(){
 
   it("returns guessed translation if missingBehaviour is set to guess", function(){
     I18n.missingBehaviour = 'guess'
-    actual = I18n.translate("invalid.this_Is_AutomaticallyGeneratedTranslation");
+    actual = I18n.translate("invalid.this_is_automatically_generated_translation");
     expected = 'this is automatically generated translation';
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION
I had a bug: not all underscores replaced with spaces. I used regexp /_/g to replace _all_ underscores to spaces.