### PR TITLE
Uppercase first letter for missing translation

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -679,7 +679,7 @@
       var s = scope.split('.').slice(-1)[0];
       //replace underscore with space && camelcase with space and lowercase letter
       return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
-          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g,
+          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g.charAt(0).toUpperCase() + s.slice(1),
           function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
     }
 

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -677,10 +677,11 @@
     if(this.missingBehaviour === 'guess'){
       //get only the last portion of the scope
       var s = scope.split('.').slice(-1)[0];
+      s = s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g,
+      function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
+      s = s.charAt(0).toUpperCase() + s.slice(1);
       //replace underscore with space && camelcase with space and lowercase letter
-      return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
-          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g.charAt(0).toUpperCase() + s.slice(1),
-          function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
+      return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') + s;         
     }
 
     var localeForTranslation = (options != null && options.locale != null) ? options.locale : this.currentLocale();

--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -54,7 +54,7 @@ describe("Translate", function(){
     expect(actual_1).toEqual(expected_1);
 
     var actual_2 = I18n.translate("invalid.this_is_automatically_generated_translation");
-    var expected_2 = 'this is automatically generated translation';
+    var expected_2 = 'This is automatically generated translation';
     expect(actual_2).toEqual(expected_2);
   });
 


### PR DESCRIPTION
'guess' is just changing underscores to spaces. Is it good idea to uppercase first letter for key?
Example:
   key - 'empty_data_set'
   missing guess - 'Empty data set'
It's just gets first letter of key, uppercase it and than join all letters except first :)
