### PR TITLE
Setup GitHub Workflow simulate Travis builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,111 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  ruby_unit_tests:
+    name: Ruby Unit Tests
+    if: "contains(github.event.commits[0].message, '[ci skip]') == false"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        ruby:
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+        gemfile:
+          - gemfiles/i18n_0_6.gemfile
+          - gemfiles/i18n_0_7.gemfile
+          - gemfiles/i18n_0_8.gemfile
+          - gemfiles/i18n_0_9.gemfile
+          - gemfiles/i18n_1_0.gemfile
+          - gemfiles/i18n_1_1.gemfile
+          - gemfiles/i18n_1_2.gemfile
+          - gemfiles/i18n_1_3.gemfile
+          - gemfiles/i18n_1_4.gemfile
+          - gemfiles/i18n_1_5.gemfile
+          - gemfiles/i18n_1_6.gemfile
+          - gemfiles/i18n_1_7.gemfile
+          - gemfiles/i18n_1_8.gemfile
+        allow_failures:
+          - false
+        include:
+          - os: ubuntu
+            ruby: ruby-head
+            gemfile: gemfiles/i18n_1_8.gemfile
+            allow_failures: true
+    env:
+      BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
+      BUNDLE_PATH:    "./vendor/bundle"
+      ALLOW_FAILURES: "${{ matrix.allow_failures }}"
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - uses: actions/cache@v2
+        with:
+          path: gemfiles/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ github.ref }}-${{ github.sha }}-v2
+          restore-keys: |
+            ${{ runner.os }}-gems--${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ github.ref }}-
+            ${{ runner.os }}-gems--${{ matrix.ruby }}-${{ matrix.gemfile }}-
+            ${{ runner.os }}-gems--${{ matrix.ruby }}-
+      - name: Bundle Install
+        run: |
+          bundle install --jobs 4 --retry 3
+      - name: Test
+        run: bundle exec rake spec:ruby || $ALLOW_FAILURES
+
+  js_unit_tests:
+    name: JS Unit Tests
+    if: "contains(github.event.commits[0].message, '[ci skip]') == false"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        node:
+          - 10
+          - 12
+          - 14
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ github.ref }}-
+            ${{ runner.os }}-yarn-
+      - name: Install JS Dependencies
+        run: yarn install
+      - name: Test
+        run: npm test


### PR DESCRIPTION
https://www.reddit.com/r/ruby/comments/jt2uub/deep_dive_moving_ruby_projects_from_travis_to/

Travis will no longer be free for Open Source projects (And it's already slow for OS projects now)
This is to move to GitHub Action for CI

Jobs are split for Ruby & JS since there is no point running JS test for every ruby version / Gemfile