### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/i18n/js/middleware.rb
+++ b/lib/i18n/js/middleware.rb
@@ -45,7 +45,7 @@ module I18n
 
       def save_cache(new_cache)
         # path could be a symbolic link
-        FileUtils.mkdir_p(cache_dir) unless File.exists?(cache_dir)
+        FileUtils.mkdir_p(cache_dir) unless File.exist?(cache_dir)
         File.open(cache_path, "w+") do |file|
           file << new_cache.to_yaml
         end


### PR DESCRIPTION
Fixes the following warning:

```
warning: File.exists? is deprecated; use File.exist? instead
```