### PR TITLE
escape single quote for generating JavaScript string literal

### DIFF
--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -20,7 +20,7 @@ module I18n
         end
 
         def line(locale, translations)
-          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations}'))
+          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub("'"){"\\'"}}'))
           if @js_extend
             %(#{@namespace}.translations["#{locale}"] = I18n.extend((#{@namespace}.translations["#{locale}"] || {}), #{json_literal});\n)
           else

--- a/spec/ruby/i18n/js/segment_spec.rb
+++ b/spec/ruby/i18n/js/segment_spec.rb
@@ -156,6 +156,20 @@ MyNamespace.translations["fr"] = I18n.extend((MyNamespace.translations["fr"] || 
       end
     end
 
+    context "when file includes single quote" do
+      let(:file){ "tmp/i18n-js/%{locale}.js" }
+      let(:translations){ { en: { "a" => "Test's" } } }
+
+      it "should write files" do
+        file_should_exist "en.js"
+
+        expect(File.open(File.join(temp_path, "en.js")){|f| f.read}).to eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || {}), JSON.parse('{"a":"Test\\'s"}'));
+        EOF
+      end
+    end
+
     context "when js_extend is true" do
       let(:js_extend){ true }
 


### PR DESCRIPTION
https://github.com/fnando/i18n-js/pull/605 will generate like `JSON.parse('{"a":"Test's"}')`, it is broken JS because JSON includes single quote. This PR fixes JS will be like `JSON.parse('{"a":"Test\'s"}')`.