### PR TITLE
escape double quote and backslash

### DIFF
--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -2,7 +2,8 @@ require "i18n/js/formatters/base"
 
 JSON_ESCAPE_MAP = {
   '\\"' => '\\\\"',
-  "'" => "\\'"
+  "'" => "\\'",
+  "\\" => "\\\\"
 }
 
 module I18n
@@ -25,7 +26,7 @@ module I18n
         end
 
         def line(locale, translations)
-          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/\\"|'/){|match| JSON_ESCAPE_MAP[match] }}'))
+          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/\\"|'|\\/){|match| JSON_ESCAPE_MAP[match] }}'))
           if @js_extend
             %(#{@namespace}.translations["#{locale}"] = I18n.extend((#{@namespace}.translations["#{locale}"] || {}), #{json_literal});\n)
           else

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -1,5 +1,10 @@
 require "i18n/js/formatters/base"
 
+JSON_ESCAPE_MAP = {
+  '\\"' => '\\\\"',
+  "'" => "\\'"
+}
+
 module I18n
   module JS
     module Formatters
@@ -20,7 +25,7 @@ module I18n
         end
 
         def line(locale, translations)
-          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub("'"){"\\'"}}'))
+          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/\\"|'/){|match| JSON_ESCAPE_MAP[match] }}'))
           if @js_extend
             %(#{@namespace}.translations["#{locale}"] = I18n.extend((#{@namespace}.translations["#{locale}"] || {}), #{json_literal});\n)
           else

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -25,7 +25,7 @@ module I18n
         end
 
         def line(locale, translations)
-          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/'|\\/){|match| JSON_ESCAPE_MAP[match] }}'))
+          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/#{JSON_ESCAPE_MAP.keys.join("|")}/){|match| JSON_ESCAPE_MAP.fetch(match) }}'))
           if @js_extend
             %(#{@namespace}.translations["#{locale}"] = I18n.extend((#{@namespace}.translations["#{locale}"] || {}), #{json_literal});\n)
           else

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -1,14 +1,15 @@
 require "i18n/js/formatters/base"
 
-JSON_ESCAPE_MAP = {
-  "'" => "\\'",
-  "\\" => "\\\\"
-}
-
 module I18n
   module JS
     module Formatters
       class JS < Base
+        JSON_ESCAPE_MAP = {
+          "'" => "\\'",
+          "\\" => "\\\\"
+        }.freeze
+        private_constant :JSON_ESCAPE_MAP
+
         def format(translations)
           contents = header
           translations.each do |locale, translations_for_locale|

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -1,7 +1,6 @@
 require "i18n/js/formatters/base"
 
 JSON_ESCAPE_MAP = {
-  '\\"' => '\\\\"',
   "'" => "\\'",
   "\\" => "\\\\"
 }
@@ -26,7 +25,7 @@ module I18n
         end
 
         def line(locale, translations)
-          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/\\"|'|\\/){|match| JSON_ESCAPE_MAP[match] }}'))
+          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/'|\\/){|match| JSON_ESCAPE_MAP[match] }}'))
           if @js_extend
             %(#{@namespace}.translations["#{locale}"] = I18n.extend((#{@namespace}.translations["#{locale}"] || {}), #{json_literal});\n)
           else

--- a/lib/i18n/js/formatters/js.rb
+++ b/lib/i18n/js/formatters/js.rb
@@ -26,7 +26,7 @@ module I18n
         end
 
         def line(locale, translations)
-          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/#{JSON_ESCAPE_MAP.keys.join("|")}/){|match| JSON_ESCAPE_MAP.fetch(match) }}'))
+          json_literal = @pretty_print ? translations : %(JSON.parse('#{translations.gsub(/#{Regexp.union(JSON_ESCAPE_MAP.keys)}/){|match| JSON_ESCAPE_MAP.fetch(match) }}'))
           if @js_extend
             %(#{@namespace}.translations["#{locale}"] = I18n.extend((#{@namespace}.translations["#{locale}"] || {}), #{json_literal});\n)
           else

--- a/spec/js/json_parsable.spec.js
+++ b/spec/js/json_parsable.spec.js
@@ -1,0 +1,14 @@
+describe("JSON.parse", function () {
+  it('should parse', function () {
+    expect(JSON.parse('{"a":"Test\'s"}')).toEqual({
+      a: "Test's"
+    })
+
+    expect(JSON.parse('{"a":"say \\"hello\\""}')).toEqual({
+      a: 'say "hello"'
+    });
+    expect(JSON.parse('{"double-backslash-in-double-quote":"\\"\\\\\\\\\\""}')).toEqual({
+      'double-backslash-in-double-quote': '"\\\\"'
+    });
+  })
+})

--- a/spec/ruby/i18n/js/segment_spec.rb
+++ b/spec/ruby/i18n/js/segment_spec.rb
@@ -170,6 +170,20 @@ MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || 
       end
     end
 
+    context "when file includes escaped double quote" do
+      let(:file){ "tmp/i18n-js/%{locale}.js" }
+      let(:translations){ { en: { "a" => 'say "hello"' } } }
+
+      it "should escape double quote" do
+        file_should_exist "en.js"
+
+        expect(File.open(File.join(temp_path, "en.js")){|f| f.read}).to eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || {}), JSON.parse('{"a":"say \\\\"hello\\\\""}'));
+        EOF
+      end
+    end
+
     context "when js_extend is true" do
       let(:js_extend){ true }
 

--- a/spec/ruby/i18n/js/segment_spec.rb
+++ b/spec/ruby/i18n/js/segment_spec.rb
@@ -184,6 +184,20 @@ MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || 
       end
     end
 
+    context "when file includes backslash in double quote" do
+      let(:file){ "tmp/i18n-js/%{locale}.js" }
+      let(:translations){ { en: { "double-backslash-in-double-quote" => '"\\\\"' } } }
+
+      it "should escape backslash" do
+        file_should_exist "en.js"
+
+        expect(File.open(File.join(temp_path, "en.js")){|f| f.read}).to eql <<-EOF
+MyNamespace.translations || (MyNamespace.translations = {});
+MyNamespace.translations["en"] = I18n.extend((MyNamespace.translations["en"] || {}), JSON.parse('{"double-backslash-in-double-quote":"\\\\"\\\\\\\\\\\\\\\\\\\\""}'));
+        EOF
+      end
+    end
+
     context "when js_extend is true" do
       let(:js_extend){ true }
 


### PR DESCRIPTION
Bugfix: https://github.com/fnando/i18n-js/pull/605

I tried new feature with `JSON.parse` in our Rails application and find bug to fix 🙇 

- `"` is escaped  as `\"` but it should escape as  `\\"`
  - `\` should escape as `\\`

I added test escaping on Ruby and parsing on JavaScript.