### PR TITLE
notes on listen, after initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Now you can run `guard start -i`.
 
 ### Using listen
 
-Create a file under `config/environments/development.rb` with the following content:
+Add the following to `config/environments/development.rb` file:
 
 ```ruby
 config.after_initialize do

--- a/README.md
+++ b/README.md
@@ -96,14 +96,16 @@ Now you can run `guard start -i`.
 
 ### Using listen
 
-Create a file under `config/initializers/i18n.rb` with the following content:
+Create a file under `config/environments/development.rb` with the following content:
 
 ```ruby
-# frozen_string_literal: true
-
-require "i18n-js/listen"
-
-I18nJS.listen
+config.after_initialize do
+  require "i18n-js/listen"
+  I18nJS.listen(
+    config_file: Rails.root.join("config/i18n.yml"), 
+    locales_dir: Rails.root.join("config/locales")
+  )
+end
 ```
 
 The code above will watch for changes based on `config/i18n.yml` and


### PR DESCRIPTION
Added readme notes on I18nJS.listen usage. The current suggestion on how add I18nJS.listen on an initializer leads to empty translations when server starts. If the I18nJS.listen is added in an after_initialize it works fine.