### PR TITLE
CI against Ruby 3.0 and 3.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - '3.0'
+          - 3.1
         gemfile:
           - gemfiles/i18n_0_6.gemfile
           - gemfiles/i18n_0_7.gemfile


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the CI matrix.
I have confirmed that it is all green in my forked repo.