### PR TITLE
Allow rails 7

### DIFF
--- a/lib/i18n/js/dependencies.rb
+++ b/lib/i18n/js/dependencies.rb
@@ -18,7 +18,7 @@ module I18n
         # Call this in an initializer
         def using_asset_pipeline?
           assets_pipeline_available =
-            (rails3? || rails4? || rails5? || rails6?) &&
+            (rails3? || rails4? || rails5? || rails6? || rails7?) &&
             Rails.respond_to?(:application) &&
             Rails.application.config.respond_to?(:assets)
           rails3_assets_enabled =
@@ -26,7 +26,7 @@ module I18n
             assets_pipeline_available &&
             Rails.application.config.assets.enabled != false
 
-          assets_pipeline_available && (rails4? || rails5? || rails6? || rails3_assets_enabled)
+          assets_pipeline_available && (rails4? || rails5? || rails6? || rails7? || rails3_assets_enabled)
         end
 
         private
@@ -45,6 +45,10 @@ module I18n
 
         def rails6?
           rails? && Rails.version.to_i == 6
+        end
+        
+        def rails7?
+          rails? && Rails.version.to_i == 7
         end
 
         def safe_gem_check(*args)


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [ ] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

I know v4 is [coming](https://github.com/fnando/i18n-js/issues/590), but the asset pipeline still exists in Rails 7. So for people who don't want to upgrade this gem but do want to use Rails 7, it would be good if we could support it.

### How

I copied the implementation of https://github.com/fnando/i18n-js/pull/536