### PR TITLE
Fix pluralization fallback in i18n.js

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -433,7 +433,7 @@
       , pluralizerKey
       , message;
 
-    if (isObject(translations)) {
+    if (translations && isObject(translations)) {
       while (pluralizerKeys.length) {
         pluralizerKey = pluralizerKeys.shift();
         if (isSet(translations[pluralizerKey])) {

--- a/spec/js/pluralization.spec.js
+++ b/spec/js/pluralization.spec.js
@@ -148,6 +148,15 @@ describe("Pluralization", function(){
     expect(I18n.p(5, "inbox", { count: 5 })).toEqual('You have 5 messages');
   });
 
+  it("fallback to default locale when I18n.fallbacks is enabled and value is null", function() {
+    I18n.locale = "pt-BR";
+    I18n.fallbacks = true;
+    I18n.translations["pt-BR"].inbox = null;
+    expect(I18n.p(0, "inbox", { count: 0 })).toEqual("You have no messages");
+    expect(I18n.p(1, "inbox", { count: 1 })).toEqual("You have 1 message");
+    expect(I18n.p(5, "inbox", { count: 5 })).toEqual("You have 5 messages");
+  });
+
   it("fallback to 'other' scope", function() {
     I18n.locale = "pt-BR";
     I18n.fallbacks = true;


### PR DESCRIPTION
I ran into this error with pluralization in I18n.js v3.8.0 when fallbacks are enabled.

> Error: TypeError: null is not an object (evaluating 'translations[pluralizerKey]')

Here are the steps to reproduce:

```js
I18n.translations = {en: {items: {one: "1 item", other: "%{count} items"}}, fr: {items: null}};
I18n.defaultLocale = "en";
I18n.locale = "fr";
I18n.fallbacks = true
I18n.t("items", {count: 1})
// Error: TypeError: null is not an object (evaluating 'translations[pluralizerKey]')
```

From my understanding this gem provides fallback support in two different ways: Ruby side and JavaScript side. I have disabled the Ruby fallbacks since it clones the locale value which is inefficient for how I have it setup. I'd like to rely on the JavaScript fallbacks but ran into this error.

Checking if `translations` exists before calling `pluralizerKey` seems to fix this issue.