### PR TITLE
Add test examples for using scope option with defaults

### DIFF
--- a/spec/js/translate.spec.js
+++ b/spec/js/translate.spec.js
@@ -155,6 +155,21 @@ describe("Translate", function(){
       expect(actual).toEqual("Hello stranger!");
     });
 
+    it("uses scope provided in defaults if scope as an array doesn't exist", function() {
+      actual = I18n.translate(["greetings", "monster"], {
+        defaults: [{ scope: "greetings.stranger" }]
+      });
+      expect(actual).toEqual("Hello stranger!");
+    });
+
+    it("uses scope provided in defaults if scope with a base scope doesn't exist", function() {
+      actual = I18n.translate("monster", {
+        defaults: [{ scope: "greetings.stranger" }],
+        scope: "greetings"
+      });
+      expect(actual).toEqual("Hello stranger!");
+    });
+
     it("continues to fallback until a scope is found", function() {
       var defaults = [{scope: "foo"}, {scope: "hello"}];
 


### PR DESCRIPTION
# What
I've added two new test examples, following the hint from @PikachuEXE [here](https://github.com/fnando/i18n-js/discussions/648#discussioncomment-2677441).

# Why
It seems that the fallback to the default scope is not working when the scope option is present.
Instead of giving me the scope in the defaults, it returns a missing translation message.