### PR TITLE
Support multiple locales dirs in listen backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <small>
     Oh, you don't use Ruby? No problem! You can still use i18n-js
     <br>
-    and the 
+    and the
     <a href="https://www.npmjs.com/package/i18n-js/v/latest">companion JavaScript package</a>.
   </small>
 </p>
@@ -226,8 +226,14 @@ end
 ```
 
 The code above will watch for changes based on `config/i18n.yml` and
-`config/locales`. You can customize these options with
-`I18nJS.listen(config_file: "config/i18n.yml", locales_dir: "config/locales")`.
+`config/locales`. You can customize these options:
+
+* config_file - i18n-js configuration file
+* locales_dir - one or multiple directories to watch for locales changes
+* options - passed directly to [listen gem](https://github.com/guard/listen/#options)
+
+Example:
+`I18nJS.listen(config_file: "config/i18n.yml", locales_dir: ["config/locales", "app/views"], options: {only: %r{.yml$})`.
 
 ### Integrating with your frontend
 


### PR DESCRIPTION
In addition allow to configure Listen by passing options.

The usecase: having multiple places from where the locales are loaded.
We're using https://github.com/tiramizoo/fractual_i18n but it can be any other generic case.

This helps us to configure backend via:
```ruby
  I18nJS.listen(
    locales_dir: [Rails.root.join("config/locales"), Rails.root.join("app/views")],
    options: {only: %r{.yml$}}
  )
```