### PR TITLE
Add `I18nJS.listen(run_on_start:)` to control if files should be exported during boot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Changed] `I18n.listen(run_on_start:)` was added to control if files should be
+  exported during `I18n.listen`'s boot. The default value is `true`.
+
 ## v4.0.1
 
 - [Fixed] Shell out export to avoid handling I18n reloading heuristics.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ The code above will watch for changes based on `config/i18n.yml` and
 - `config_file` - i18n-js configuration file
 - `locales_dir` - one or multiple directories to watch for locales changes
 - `options` - passed directly to [listen](https://github.com/guard/listen/#options)
+- `run_on_start` - export files on start. Defaults to `true`. When disabled,
+  files will be exported only when there are file changes.
 
 Example:
 
@@ -238,7 +240,8 @@ Example:
 I18nJS.listen(
   config_file: "config/i18n.yml",
   locales_dir: ["config/locales", "app/views"],
-  options: {only: %r{.yml$}
+  options: {only: %r{.yml$}},
+  run_on_start: false
 )
 ```
 

--- a/lib/i18n-js/listen.rb
+++ b/lib/i18n-js/listen.rb
@@ -8,6 +8,7 @@ module I18nJS
   def self.listen(
     config_file: Rails.root.join("config/i18n.yml"),
     locales_dir: Rails.root.join("config/locales"),
+    run_on_start: true,
     options: {}
   )
     return unless Rails.env.development?
@@ -27,7 +28,7 @@ module I18nJS
     debug("Watching #{relative_paths.inspect}")
 
     listener(config_file, locales_dirs.map(&:to_s), options).start
-    I18nJS.call(config_file: config_file)
+    I18nJS.call(config_file: config_file) if run_on_start
   end
 
   def self.relative_path(path)


### PR DESCRIPTION
Defaults to `true`.

Close #667.
