### PR TITLE
Add I18nJS::Plugin.after_export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Added] Add `I18nJS::Plugin.after_export(files:)` method, that's called
+  whenever whenever I18nJS finishes exporting files. You can use it to further
+  process files, or generate new files based on the exported files.
+
 ## v4.1.0 - Dec 09, 2022
 
 - [Added] Parse configuration files as erb.

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -34,6 +34,8 @@ module I18nJS
       exported_files += export_group(group, config)
     end
 
+    plugins.each {|plugin| plugin.after_export(files: exported_files.dup) }
+
     exported_files
   end
 

--- a/lib/i18n-js/embed_fallback_translations_plugin.rb
+++ b/lib/i18n-js/embed_fallback_translations_plugin.rb
@@ -6,21 +6,10 @@ module I18nJS
   class EmbedFallbackTranslationsPlugin < I18nJS::Plugin
     CONFIG_KEY = :embed_fallback_translations
 
-    # This method must set up the basic plugin configuration, like adding the
-    # config's root key in case your plugin accepts configuration (defined via
-    # the config file).
-    #
-    # If you don't add this key, the linter will prevent non-default keys from
-    # being added to the configuration file.
     def self.setup
       I18nJS::Schema.root_keys << CONFIG_KEY
     end
 
-    # In case your plugin accepts configuration, this is where you must validate
-    # the configuration, making sure only valid keys and type is provided.
-    # If the configuration contains invalid data, then you must raise an
-    # exception using something like
-    # `raise I18nJS::Schema::InvalidError, error_message`.
     def self.validate_schema(config:)
       return unless config.key?(CONFIG_KEY)
 
@@ -33,14 +22,6 @@ module I18nJS
       schema.expect_enabled_config(CONFIG_KEY, plugin_config[:enabled])
     end
 
-    # This method is responsible for transforming the translations. The
-    # translations you'll receive may be already be filtered by other plugins
-    # and by the default filtering itself. If you need to access the original
-    # translations, use `I18nJS.translations`.
-    #
-    # Make sure you always check whether your plugin is active before
-    # transforming translations; otherwise, opting out transformation won't be
-    # possible.
     def self.transform(translations:, config:)
       return translations unless config.dig(CONFIG_KEY, :enabled)
 

--- a/lib/i18n-js/plugin.rb
+++ b/lib/i18n-js/plugin.rb
@@ -23,16 +23,41 @@ module I18nJS
   end
 
   class Plugin
+    # This method must set up the basic plugin configuration, like adding the
+    # config's root key in case your plugin accepts configuration (defined via
+    # the config file).
+    #
+    # If you don't add this key, the linter will prevent non-default keys from
+    # being added to the configuration file.
     def self.transform(translations:, config:) # rubocop:disable Lint/UnusedMethodArgument
       translations
     end
 
-    # Must raise I18nJS::SchemaInvalidError with the error message if schema
-    # validation has failed.
+    # In case your plugin accepts configuration, this is where you must validate
+    # the configuration, making sure only valid keys and type is provided.
+    # If the configuration contains invalid data, then you must raise an
+    # exception using something like
+    # `raise I18nJS::Schema::InvalidError, error_message`.
     def self.validate_schema(config:)
     end
 
+    # This method is responsible for transforming the translations. The
+    # translations you'll receive may be already be filtered by other plugins
+    # and by the default filtering itself. If you need to access the original
+    # translations, use `I18nJS.translations`.
+    #
+    # Make sure you always check whether your plugin is active before
+    # transforming translations; otherwise, opting out transformation won't be
+    # possible.
     def self.setup
+    end
+
+    # This method is called whenever `I18nJS.call(**kwargs)` finishes exporting
+    # JSON files based on your configuration.
+    #
+    # You can use it to further process exported files, or generate new files
+    # based on the translations that have been exported.
+    def self.after_export(files:)
     end
   end
 end

--- a/test/i18n-js/plugin_test.rb
+++ b/test/i18n-js/plugin_test.rb
@@ -70,6 +70,33 @@ class PluginTest < Minitest::Test
     assert_includes sample_plugin.calls, config
   end
 
+  test "runs after_export event" do
+    I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
+    expected_files = [
+      "test/output/en.json",
+      "test/output/es.json",
+      "test/output/pt.json"
+    ]
+
+    sample_plugin = create_plugin do
+      def self.exported_files
+        @exported_files ||= []
+      end
+
+      def self.after_export(files:)
+        exported_files.push(*files)
+      end
+    end
+
+    I18nJS.register_plugin(sample_plugin)
+
+    actual_files =
+      I18nJS.call(config_file: "./test/config/locale_placeholder.yml")
+
+    assert_exported_files expected_files, actual_files
+    assert_exported_files expected_files, sample_plugin.exported_files
+  end
+
   test "loads plugins using rubygems" do
     Gem
       .expects(:find_files)


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Adds `I18nJS::Plugin.after_export(files:)` to the plugin api. This method is called after i18n-js finishes exporting all translation files.

### Why

To enable further processing through plugins.

### Known limitations

N/A
