### PR TITLE
Pass configuration to `I18nJS::Plugin.after_export(files:, config:)`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Prefix your message with one of the following:
 - [Added] Add `I18nJS::Plugin.after_export(files:)` method, that's called
   whenever whenever I18nJS finishes exporting files. You can use it to further
   process files, or generate new files based on the exported files.
+- [Changed] Pass configuration to
+  `I18nJS::Plugin.after_export(files:, config:)`.
 
 ## v4.1.0 - Dec 09, 2022
 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,14 @@ Here's the base `I18nJS::Plugin` class with the documented api:
 
 module I18nJS
   class Plugin
-    # This method must set up the basic plugin configuration, like adding the
-    # config's root key in case your plugin accepts configuration (defined via
-    # the config file).
+    # This method is responsible for transforming the translations. The
+    # translations you'll receive may be already be filtered by other plugins
+    # and by the default filtering itself. If you need to access the original
+    # translations, use `I18nJS.translations`.
     #
-    # If you don't add this key, the linter will prevent non-default keys from
-    # being added to the configuration file.
+    # Make sure you always check whether your plugin is active before
+    # transforming translations; otherwise, opting out transformation won't be
+    # possible.
     def self.transform(translations:, config:)
       translations
     end
@@ -172,14 +174,12 @@ module I18nJS
     def self.validate_schema(config:)
     end
 
-    # This method is responsible for transforming the translations. The
-    # translations you'll receive may be already be filtered by other plugins
-    # and by the default filtering itself. If you need to access the original
-    # translations, use `I18nJS.translations`.
+    # This method must set up the basic plugin configuration, like adding the
+    # config's root key in case your plugin accepts configuration (defined via
+    # the config file).
     #
-    # Make sure you always check whether your plugin is active before
-    # transforming translations; otherwise, opting out transformation won't be
-    # possible.
+    # If you don't add this key, the linter will prevent non-default keys from
+    # being added to the configuration file.
     def self.setup
     end
 
@@ -188,7 +188,10 @@ module I18nJS
     #
     # You can use it to further process exported files, or generate new files
     # based on the translations that have been exported.
-    def self.after_export(files:)
+    #
+    # Make sure you always check whether your plugin is active before
+    # processing files; otherwise, opting out won't be possible.
+    def self.after_export(files:, config:)
     end
   end
 end

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -34,7 +34,9 @@ module I18nJS
       exported_files += export_group(group, config)
     end
 
-    plugins.each {|plugin| plugin.after_export(files: exported_files.dup) }
+    plugins.each do |plugin|
+      plugin.after_export(files: exported_files.dup, config: config)
+    end
 
     exported_files
   end

--- a/lib/i18n-js/plugin.rb
+++ b/lib/i18n-js/plugin.rb
@@ -23,12 +23,14 @@ module I18nJS
   end
 
   class Plugin
-    # This method must set up the basic plugin configuration, like adding the
-    # config's root key in case your plugin accepts configuration (defined via
-    # the config file).
+    # This method is responsible for transforming the translations. The
+    # translations you'll receive may be already be filtered by other plugins
+    # and by the default filtering itself. If you need to access the original
+    # translations, use `I18nJS.translations`.
     #
-    # If you don't add this key, the linter will prevent non-default keys from
-    # being added to the configuration file.
+    # Make sure you always check whether your plugin is active before
+    # transforming translations; otherwise, opting out transformation won't be
+    # possible.
     def self.transform(translations:, config:) # rubocop:disable Lint/UnusedMethodArgument
       translations
     end
@@ -41,14 +43,12 @@ module I18nJS
     def self.validate_schema(config:)
     end
 
-    # This method is responsible for transforming the translations. The
-    # translations you'll receive may be already be filtered by other plugins
-    # and by the default filtering itself. If you need to access the original
-    # translations, use `I18nJS.translations`.
+    # This method must set up the basic plugin configuration, like adding the
+    # config's root key in case your plugin accepts configuration (defined via
+    # the config file).
     #
-    # Make sure you always check whether your plugin is active before
-    # transforming translations; otherwise, opting out transformation won't be
-    # possible.
+    # If you don't add this key, the linter will prevent non-default keys from
+    # being added to the configuration file.
     def self.setup
     end
 
@@ -57,7 +57,10 @@ module I18nJS
     #
     # You can use it to further process exported files, or generate new files
     # based on the translations that have been exported.
-    def self.after_export(files:)
+    #
+    # Make sure you always check whether your plugin is active before
+    # processing files; otherwise, opting out won't be possible.
+    def self.after_export(files:, config:)
     end
   end
 end


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Pass configuration to `I18nJS::Plugin.after_export`.

### Why

so plugins can act upon configuration.

### Known limitations

N/A
