### PR TITLE
feat: speed up fallback translations plugin

### DIFF
--- a/lib/i18n-js/embed_fallback_translations_plugin.rb
+++ b/lib/i18n-js/embed_fallback_translations_plugin.rb
@@ -4,6 +4,34 @@ module I18nJS
   require "i18n-js/plugin"
 
   class EmbedFallbackTranslationsPlugin < I18nJS::Plugin
+    module Utils
+      # Based on deep_merge by Stefan Rusterholz, see <https://www.ruby-forum.com/topic/142809>.
+      # This method is used to handle I18n fallbacks. Given two equivalent path nodes in two locale trees:
+      # 1. If the node in the current locale appears to be an I18n pluralization (:one, :other, etc.),
+      #    use the node, but merge in any missing/non-nil keys from the fallback (default) locale.
+      # 2. Else if both nodes are Hashes, combine (merge) the key-value pairs of the two nodes into one,
+      #    prioritizing the current locale.
+      # 3. Else if either node is nil, use the other node.
+
+      PLURAL_KEYS = %i[zero one two few many other].freeze
+      PLURAL_MERGER = proc { |_key, v1, v2| v1 || v2 }
+      MERGER = proc do |_key, v1, v2|
+        if v1.is_a?(Hash) && v2.is_a?(Hash)
+          if (v2.keys - PLURAL_KEYS).empty?
+            v2.merge(v1, &PLURAL_MERGER).slice(*v2.keys)
+          else
+            v1.merge(v2, &MERGER)
+          end
+        else
+          v2 || v1
+        end
+      end
+
+      def self.deep_merge(target_hash, hash)
+        target_hash.merge(hash, &MERGER)
+      end
+    end
+
     def setup
       I18nJS::Schema.root_keys << config_key
     end
@@ -16,33 +44,21 @@ module I18nJS
     end
 
     def transform(translations:)
-      translations_glob = Glob.new(translations)
-      translations_glob << "*"
+      return translations unless enabled?
 
-      mapping = translations.keys.each_with_object({}) do |locale, buffer|
-        buffer[locale] = Glob.new(translations[locale]).tap do |glob|
-          glob << "*"
-        end
+      fallback_locale = I18n.default_locale.to_sym
+      locales_to_fallback = translations.keys - fallback_locale
+
+      translations_with_fallback = {}
+      translations_with_fallback[fallback_locale] = translations[fallback_locale]
+
+      locales_to_fallback.each do |locale|
+        translations_with_fallback[locale] = Utils.deep_merge(
+          translations[fallback_locale], translations[locale]
+        )
       end
 
-      default_locale = I18n.default_locale
-      default_locale_glob = mapping.delete(default_locale)
-      default_locale_paths = default_locale_glob.paths
-
-      mapping.each do |locale, glob|
-        missing_keys = default_locale_paths - glob.paths
-
-        missing_keys.each do |key|
-          components = key.split(".").map(&:to_sym)
-          fallback_translation = translations.dig(default_locale, *components)
-
-          next unless fallback_translation
-
-          translations_glob.set([locale, key].join("."), fallback_translation)
-        end
-      end
-
-      translations_glob.to_h
+      translations_with_fallback
     end
   end
 

--- a/lib/i18n-js/embed_fallback_translations_plugin.rb
+++ b/lib/i18n-js/embed_fallback_translations_plugin.rb
@@ -5,16 +5,19 @@ module I18nJS
 
   class EmbedFallbackTranslationsPlugin < I18nJS::Plugin
     module Utils
-      # Based on deep_merge by Stefan Rusterholz, see <https://www.ruby-forum.com/topic/142809>.
-      # This method is used to handle I18n fallbacks. Given two equivalent path nodes in two locale trees:
-      # 1. If the node in the current locale appears to be an I18n pluralization (:one, :other, etc.),
-      #    use the node, but merge in any missing/non-nil keys from the fallback (default) locale.
-      # 2. Else if both nodes are Hashes, combine (merge) the key-value pairs of the two nodes into one,
-      #    prioritizing the current locale.
+      # Based on deep_merge by Stefan Rusterholz, see
+      # <https://www.ruby-forum.com/topic/142809>.
+      # This method is used to handle I18n fallbacks. Given two equivalent path
+      # nodes in two locale trees:
+      # 1. If the node in the current locale appears to be an I18n pluralization
+      #    (:one, :other, etc.), use the node, but merge in any missing/non-nil
+      #    keys from the fallback (default) locale.
+      # 2. Else if both nodes are Hashes, combine (merge) the key-value pairs of
+      #    the two nodes into one, prioritizing the current locale.
       # 3. Else if either node is nil, use the other node.
 
       PLURAL_KEYS = %i[zero one two few many other].freeze
-      PLURAL_MERGER = proc { |_key, v1, v2| v1 || v2 }
+      PLURAL_MERGER = proc {|_key, v1, v2| v1 || v2 }
       MERGER = proc do |_key, v1, v2|
         if v1.is_a?(Hash) && v2.is_a?(Hash)
           if (v2.keys - PLURAL_KEYS).empty?
@@ -47,10 +50,11 @@ module I18nJS
       return translations unless enabled?
 
       fallback_locale = I18n.default_locale.to_sym
-      locales_to_fallback = translations.keys - fallback_locale
+      locales_to_fallback = translations.keys - [fallback_locale]
 
       translations_with_fallback = {}
-      translations_with_fallback[fallback_locale] = translations[fallback_locale]
+      translations_with_fallback[fallback_locale] =
+        translations[fallback_locale]
 
       locales_to_fallback.each do |locale|
         translations_with_fallback[locale] = Utils.deep_merge(

--- a/test/fixtures/embed/translations.yml
+++ b/test/fixtures/embed/translations.yml
@@ -1,0 +1,14 @@
+---
+en:
+  words:
+    bye: "Goodbye!"
+    hello: "Hi!"
+
+  counting:
+    one: This is one!
+
+pt:
+  words:
+    bye: "Adeus!"
+  counting:
+    one: Esse é um!

--- a/test/fixtures/expected/embed_fallback_translations.json
+++ b/test/fixtures/expected/embed_fallback_translations.json
@@ -1,19 +1,40 @@
 {
   "en": {
     "bunny rabbit adventure": "bunny rabbit adventure",
+    "counting": {
+      "one": "This is one!"
+    },
     "hello sunshine!": "hello sunshine!",
-    "time for bed!": "time for bed!"
+    "time for bed!": "time for bed!",
+    "words": {
+      "bye": "Goodbye!",
+      "hello": "Hi!"
+    }
   },
   "es": {
     "bunny rabbit adventure": "conejito conejo aventura",
-    "bye": "adios",
+    "counting": {
+      "one": "This is one!"
+    },
     "hello sunshine!": "hello sunshine!",
-    "time for bed!": "hora de acostarse!"
+    "time for bed!": "hora de acostarse!",
+    "words": {
+      "bye": "Goodbye!",
+      "hello": "Hi!"
+    },
+    "bye": "adios"
   },
   "pt": {
     "bunny rabbit adventure": "a aventura da coelhinha",
-    "bye": "tchau",
+    "counting": {
+      "one": "Esse é um!"
+    },
     "hello sunshine!": "hello sunshine!",
-    "time for bed!": "hora de dormir!"
+    "time for bed!": "hora de dormir!",
+    "words": {
+      "bye": "Adeus!",
+      "hello": "Hi!"
+    },
+    "bye": "tchau"
   }
 }

--- a/test/i18n-js/embed_fallback_translations_plugin_test.rb
+++ b/test/i18n-js/embed_fallback_translations_plugin_test.rb
@@ -7,7 +7,10 @@ class EmbedFallbackTranslationsPluginTest < Minitest::Test
     require "i18n-js/embed_fallback_translations_plugin"
     I18nJS.register_plugin(I18nJS::EmbedFallbackTranslationsPlugin)
 
-    I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
+    I18n.load_path << Dir[
+      "./test/fixtures/yml/*.yml",
+      "./test/fixtures/embed/*.yml"
+    ]
     actual_files =
       I18nJS.call(config_file: "./test/config/embed_fallback_translations.yml")
 


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Speed up the fallback translations plugin.
`deep_merge` code extracted from `i18n-js` v3.

### Why

Current versions with `Glob` became too slow on large localization files.
For our use case (20 locales, 20000 keys each), I wait ~20 minutes and kill the process.

`deep_merge` versions from `v3` works instantly. So, I have extracted the `deep_merge` from `v3` into `v4`.

### Known limitations

N/A
