### PR TITLE
feat: avoid rewriting exported JSON localizaton files if identical

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -74,6 +74,12 @@ module I18nJS
     digest = Digest::MD5.hexdigest(contents)
     file_path = file_path.gsub(/:digest/, digest)
 
+    # Don't rewrite the file if it already exists and has the same content.
+    # It helps the asset pipeline or webpack understand that file wasn't changed.
+    if File.exist?(file_path) && File.read(file_path) == contents
+      return file_path
+    end
+
     File.open(file_path, "w") do |file|
       file << contents
     end


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Fixes #693.

Running `i18n export` should not rewrite exported JSON localization files if the content hasn't changed.
In `v3`, it was fixed in #473.

### Why

Fixes #693.

### Known limitations

N/A
