### PR TITLE
Sort translations after filtering them out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Prefix your message with one of the following:
 ## Unreleased
 
 - [Changed] Do not re-export files whose contents haven't changed.
+- [Changed] Translations will always be deep sorted.
 
 ## v4.2.1 - Dec 25, 2022
 

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -77,7 +77,8 @@ module I18nJS
     file_path = file_path.gsub(/:digest/, digest)
 
     # Don't rewrite the file if it already exists and has the same content.
-    # It helps the asset pipeline or webpack understand that file wasn't changed.
+    # It helps the asset pipeline or webpack understand that file wasn't
+    # changed.
     if File.exist?(file_path) && File.read(file_path) == contents
       return file_path
     end

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -13,6 +13,7 @@ require "digest/md5"
 require_relative "i18n-js/schema"
 require_relative "i18n-js/version"
 require_relative "i18n-js/plugin"
+require_relative "i18n-js/sort_hash"
 
 module I18nJS
   MissingConfigError = Class.new(StandardError)
@@ -51,6 +52,7 @@ module I18nJS
         end
       end
 
+    filtered_translations = sort_hash(filtered_translations)
     output_file_path = File.expand_path(group[:file])
     exported_files = []
 

--- a/lib/i18n-js/sort_hash.rb
+++ b/lib/i18n-js/sort_hash.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module I18nJS
+  def self.sort_hash(hash)
+    return hash unless hash.is_a?(Hash)
+
+    hash.keys.sort_by(&:to_s).each_with_object({}) do |key, seed|
+      value = hash[key]
+      seed[key] = value.is_a?(Hash) ? sort_hash(value) : value
+    end
+  end
+end

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -202,8 +202,7 @@ class ExporterTest < Minitest::Test
     I18nJS.call(config_file: "./test/config/everything.yml")
 
     # mtime should be the same
-    assert_equal exported_file_mtime, 
-                 File.mtime(exported_file_path)
+    assert_equal exported_file_mtime, File.mtime(exported_file_path)
   end
 
   test "overwrite exported files if not identical" do
@@ -215,7 +214,7 @@ class ExporterTest < Minitest::Test
     assert_exported_files [exported_file_path], actual_files
 
     # Change content of existed exported file (add space to the end of file).
-    File.open(exported_file_path, 'a') { |f| f << ' ' }
+    File.open(exported_file_path, "a") {|f| f << " " }
     exported_file_mtime = File.mtime(exported_file_path)
 
     # Second run

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -147,7 +147,7 @@ class ExporterTest < Minitest::Test
                      "test/output/group.json"
   end
 
-  test "export files using erb" do
+  test "exports files using erb" do
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
     actual_files = I18nJS.call(config_file: "./test/config/config.yml.erb")
 
@@ -189,7 +189,7 @@ class ExporterTest < Minitest::Test
                      "test/output/everything.json"
   end
 
-  test "do not overwrite exported files if identical" do
+  test "does not overwrite exported files if identical" do
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
     exported_file_path = "test/output/everything.json"
 
@@ -198,6 +198,8 @@ class ExporterTest < Minitest::Test
     assert_exported_files [exported_file_path], actual_files
     exported_file_mtime = File.mtime(exported_file_path)
 
+    sleep 0.1
+
     # Second run
     I18nJS.call(config_file: "./test/config/everything.yml")
 
@@ -205,7 +207,7 @@ class ExporterTest < Minitest::Test
     assert_equal exported_file_mtime, File.mtime(exported_file_path)
   end
 
-  test "overwrite exported files if not identical" do
+  test "overwrites exported files if not identical" do
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
     exported_file_path = "test/output/everything.json"
 
@@ -216,6 +218,8 @@ class ExporterTest < Minitest::Test
     # Change content of existed exported file (add space to the end of file).
     File.open(exported_file_path, "a") {|f| f << " " }
     exported_file_mtime = File.mtime(exported_file_path)
+
+    sleep 0.1
 
     # Second run
     I18nJS.call(config_file: "./test/config/everything.yml")

--- a/test/i18n-js/sort_hash_test.rb
+++ b/test/i18n-js/sort_hash_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SortHashTest < Minitest::Test
+  test "returns non-hash objects" do
+    assert_equal 1, I18nJS.sort_hash(1)
+  end
+
+  test "sorts shallow hash" do
+    expected = {a: 1, b: 2, c: 3}
+
+    assert_equal expected, I18nJS.sort_hash(c: 3, a: 1, b: 2)
+  end
+
+  test "sorts nested hash" do
+    expected = {a: {b: 1, c: 2}, d: 3}
+
+    assert_equal expected, I18nJS.sort_hash(d: 3, a: {c: 2, b: 1})
+  end
+end


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Deep sort translations after filtering them out.

### Why

This is one of the advertised features of v4, but turns I never actually implemented it.

Close #691.

### Known limitations

Given this is a built-in behaviour, it can't be disabled nor replaced.
