### PR TITLE
Implement glob patterns for lint translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Changed] Allow glob patterns in lint:translations.
+
 ## v4.2.3 - Mar 29, 2023
 
 - [Fixed] Load plugins when running `i18n lint:*` commands.

--- a/README.md
+++ b/README.md
@@ -351,13 +351,14 @@ lint_translations:
   ignore:
     - en.mailer.login.subject
     - en.mailer.login.body
+    - en.faker.* 
 ```
 
 > **Note**:
 >
-> In order to avoid mistakenly ignoring keys, this configuration option only
-> accepts the full translation scope, rather than accepting a pattern like
-> `pt.ignored.scope.*`.
+> In order to avoid mistakenly ignoring keys, prefer using a full list of translations
+> instead of using a pattern like `pt.ignored.scope.*`. We recommend only using
+> patterns for excluding scopes coming from modules, such as `en.faker.*`.
 
 ### Linting your JavaScript/TypeScript files
 


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Allow for Globs for `lint:translations`.

### Why

It's very hard to maintain a list of ignored translations when you have several locales and gems such as faker installed.
See: https://github.com/fnando/i18n-js/issues/707

### Known limitations

Not sure
