### PR TITLE
Remove benchmark gem

### DIFF
--- a/lib/i18n-js/cli/export_command.rb
+++ b/lib/i18n-js/cli/export_command.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "benchmark"
-
 module I18nJS
   class CLI
     class ExportCommand < Command
@@ -69,7 +67,7 @@ module I18nJS
           )
         end
 
-        time = Benchmark.realtime do
+        time = benchmark_realtime do
           load_require_file!(require_file) if require_file
           I18nJS.call(config_file:)
         end
@@ -89,6 +87,12 @@ module I18nJS
 
         options[:config_file] ||= config_file if File.file?(config_file)
         options[:require_file] ||= require_file if File.file?(require_file)
+      end
+
+      private def benchmark_realtime
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        yield
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
       end
     end
   end


### PR DESCRIPTION
It issues a deprecation warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.

Since the used method is very simple, there is no need for dependency
