### PR TITLE
Update README to document .* suffix for nested key exclusion patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ translations:
   - file: app/frontend/locales/en.json
     patterns:
       - "*"
-      - "!*.activerecord"
-      - "!*.errors"
-      - "!*.number.nth"
+      - "!*.activerecord.*"
+      - "!*.errors.*"
+      - "!*.number.nth.*"
 
   - file: app/frontend/locales/:locale.:digest.json
     patterns:
@@ -96,9 +96,9 @@ translations:
   - file: app/frontend/translations.json
     patterns:
       - "<%= group %>.*"
-      - "!<%= group %>.activerecord"
-      - "!<%= group %>.errors"
-      - "!<%= group %>.number.nth"
+      - "!<%= group %>.activerecord.*"
+      - "!<%= group %>.errors.*"
+      - "!<%= group %>.number.nth.*"
 ```
 
 ### Exporting locale.yml to locale.json
@@ -339,9 +339,9 @@ translations:
   - file: app/frontend/locales/en.json
     patterns:
       - "*"
-      - "!*.activerecord"
-      - "!*.errors"
-      - "!*.number.nth"
+      - "!*.activerecord.*"
+      - "!*.errors.*"
+      - "!*.number.nth.*"
 
   - file: app/frontend/locales/:locale.:digest.json
     patterns:


### PR DESCRIPTION
### What

The glob gem v0.4.1 changed pattern matching to anchor non-wildcard patterns with `$`, meaning `!*.activerecord` no longer excludes nested keys like `en.activerecord.attributes`. Documents the correct pattern `!*.activerecord.*` to properly exclude all nested translations. 

https://github.com/fnando/glob/commit/7baf6cd5d49e6b3df8343da78b602249bcdece55

### Why

After upgrading the glob gem to v0.4.1, exclusion patterns like `!*.activerecord` stopped matching nested keys. The README showed the same syntax, so it wasn't clear why the documented patterns weren't working. This updates the README to use `!*.activerecord.*` so the documentation reflects what actually works with glob v0.4.1+. The updated patterns are also backwards compatible with older versions of glob.
