### PR TITLE
Add trailing newline to export json

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -70,7 +70,7 @@ module I18nJS
   def self.write_file(file_path, translations)
     FileUtils.mkdir_p(File.dirname(file_path))
 
-    contents = ::JSON.pretty_generate(translations) + "\n"
+    contents = "#{::JSON.pretty_generate(translations)}\n"
     digest = Digest::MD5.hexdigest(contents)
     file_path = file_path.gsub(":digest", digest)
 

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -70,7 +70,7 @@ module I18nJS
   def self.write_file(file_path, translations)
     FileUtils.mkdir_p(File.dirname(file_path))
 
-    contents = ::JSON.pretty_generate(translations)
+    contents = ::JSON.pretty_generate(translations) + "\n"
     digest = Digest::MD5.hexdigest(contents)
     file_path = file_path.gsub(":digest", digest)
 

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -120,20 +120,20 @@ class ExporterTest < Minitest::Test
     actual_files = I18nJS.call(config_file: "./test/config/digest.yml")
 
     expected_files = [
-      "test/output/en.677728247a2f2111271f43d6a9c07d1a.json",
-      "test/output/es.d69fc73259977c7d14254b019ff85ec5.json",
-      "test/output/pt.c7ff3b8cc02447b25a1375854ea718f5.json"
+      "test/output/en.913d6b883381e2f2eefaa24054591aa6.json",
+      "test/output/es.0158e18c349c0f67702b24f750431143.json",
+      "test/output/pt.5b66b78c6d06dc6e0783f47f2d46940f.json"
     ]
 
     assert_exported_files expected_files, actual_files
     assert_json_file "test/fixtures/expected/multiple_files/en.json",
-                     "test/output/en.677728247a2f2111271f43d6a9c07d1a.json"
+                     "test/output/en.913d6b883381e2f2eefaa24054591aa6.json"
 
     assert_json_file "test/fixtures/expected/multiple_files/es.json",
-                     "test/output/es.d69fc73259977c7d14254b019ff85ec5.json"
+                     "test/output/es.0158e18c349c0f67702b24f750431143.json"
 
     assert_json_file "test/fixtures/expected/multiple_files/pt.json",
-                     "test/output/pt.c7ff3b8cc02447b25a1375854ea718f5.json"
+                     "test/output/pt.5b66b78c6d06dc6e0783f47f2d46940f.json"
   end
 
   test "exports files using groups" do

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -18,6 +18,15 @@ class ExporterTest < Minitest::Test
                      "test/output/everything.json"
   end
 
+  test "exported files end with a trailing newline" do
+    I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
+    I18nJS.call(config_file: "./test/config/everything.yml")
+
+    contents = File.read("test/output/everything.json")
+
+    assert contents.end_with?("\n"), "Expected exported JSON file to end with a trailing newline"
+  end
+
   test "exports all translations (json config)" do
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
     actual_files = I18nJS.call(config_file: "./test/config/everything.json")

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -24,7 +24,7 @@ class ExporterTest < Minitest::Test
 
     contents = File.read("test/output/everything.json")
 
-    assert contents.end_with?("\n"), "Expected exported JSON file to end with a trailing newline"
+    assert contents.end_with?("\n")
   end
 
   test "exports all translations (json config)" do


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Add a trailing newline to JSON files generated by `i18n export`.

### Why

`JSON.pretty_generate` does not include a trailing newline. POSIX convention expects text files to end with a newline, and without one, Git shows a "No newline at end of file" warning in diffs.

### Known limitations

N/A
