### PR TITLE
Use pipeline config for plugin ordering and execution.

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -30,13 +30,13 @@ jobs:
         with:
           path: vendor/bundle
           key: >
-            ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles(matrix.gemfile) }} #magic___^_^___line
+            ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles(matrix.gemfile) }}
       - uses: actions/cache@v4
         id: npm-cache
         with:
           path: vendor/bundle
           key: >
-            ${{ runner.os }}-${{ matrix.node }}-npm-${{ hashFiles('package.json') }} #magic___^_^___line
+            ${{ runner.os }}-${{ matrix.node }}-npm-${{ hashFiles('package.json') }}
       - name: Set up Node
         uses: actions/setup-node@v4.0.2
         with:

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -9,14 +9,12 @@ on:
 
 jobs:
   build:
-    name:
-      Tests with Ruby ${{ matrix.ruby }}, Node ${{ matrix.node }} and ${{
-      matrix.gemfile }}
+    name: Tests with Ruby ${{ matrix.ruby }}, Node ${{ matrix.node }} and ${{ matrix.gemfile }}
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.4"]
+        ruby: ["3.4", "3.5", "4.0"]
         node: ["22", "24"]
         gemfile:
           - Gemfile
@@ -32,17 +30,13 @@ jobs:
         with:
           path: vendor/bundle
           key: >
-            ${{ runner.os }}-${{ matrix.ruby }}-gems-${{
-            hashFiles(matrix.gemfile) }}
-
+            ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles(matrix.gemfile) }} #magic___^_^___line
       - uses: actions/cache@v4
         id: npm-cache
         with:
           path: vendor/bundle
           key: >
-            ${{ runner.os }}-${{ matrix.node }}-npm-${{
-            hashFiles('package.json') }}
-
+            ${{ runner.os }}-${{ matrix.node }}-npm-${{ hashFiles('package.json') }} #magic___^_^___line
       - name: Set up Node
         uses: actions/setup-node@v4.0.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Changed] Plugin configuration moved from top-level keys to a `pipeline:`
+  array in the config file. Each entry requires a `plugin:` key identifying the
+  plugin and an `enabled:` key. Plugin-specific options are defined inline in
+  the same stage object.
+- [Changed] `I18nJS::Plugin.key` is now a class method returning a String.
+  Previously it was an instance method called `config_key` that returned a
+  Symbol.
+- [Changed] `I18nJS::Plugin#initialize` now accepts `plugin_config:` and
+  `main_config:` instead of a single `config:` argument.
+- [Changed] `I18nJS::Plugin#config` now returns only the plugin's own
+  configuration slice instead of the full main config.
+- [Changed] `I18nJS.initialize_plugins!` now returns the list of active plugin
+  instances. The `I18nJS.plugins` accessor has been removed.
+- [Changed] `I18nJS::Schema.root_keys` is now a frozen Array. Plugins no
+  longer need to register a root key in their `setup` method.
+- [Changed] Schema validation paths in `validate_schema` are now relative to
+  the plugin's own config root. Remove the leading `config_key` segment from
+  all paths passed to `schema.*` helpers.
+- [Removed] The `check:` root key is no longer recognised by the schema
+  validator. Remove it from your config file.
+- [Added] A single plugin class can now appear multiple times in the pipeline
+  with different configurations, each running as an independent instance.
+
 ## v4.2.3 - Mar 29, 2023
 
 - [Fixed] Load plugins when running `i18n lint:*` commands.

--- a/MIGRATING_CONFIG_FOR_USERS.md
+++ b/MIGRATING_CONFIG_FOR_USERS.md
@@ -1,0 +1,190 @@
+# Migrating Your Configuration File
+
+This guide covers the changes you need to make to your `config/i18n.yml` (or
+equivalent) after the switch to the `pipeline:` API.
+
+---
+
+## What changed
+
+Plugin configuration used to live at the top level of the config file, each
+plugin using its own root key. All plugins are now listed in a single
+`pipeline:` array. The order of entries in the array determines the order in
+which plugins run.
+
+---
+
+## 1. `embed_fallback_translations`
+
+**Before**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+embed_fallback_translations:
+  enabled: true
+```
+
+**After**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+pipeline:
+  - plugin: embed_fallback_translations
+    enabled: true
+```
+
+---
+
+## 2. `export_files`
+
+**Before**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+export_files:
+  enabled: true
+  files:
+    - template: path/to/template.erb
+      output: "%{dir}/%{base_name}.ts"
+```
+
+**After**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+pipeline:
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: path/to/template.erb
+        output: "%{dir}/%{base_name}.ts"
+```
+
+Plugin-specific keys (`files:` in this case) move into the pipeline stage
+object, directly alongside `plugin:` and `enabled:`.
+
+---
+
+## 3. Multiple plugins
+
+When you use more than one plugin, list them all under the same `pipeline:`
+key. The plugins run in the order they are listed.
+
+**Before**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+embed_fallback_translations:
+  enabled: true
+
+export_files:
+  enabled: true
+  files:
+    - template: path/to/template.erb
+      output: "%{dir}/%{base_name}.ts"
+```
+
+**After**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+pipeline:
+  - plugin: embed_fallback_translations
+    enabled: true
+
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: path/to/template.erb
+        output: "%{dir}/%{base_name}.ts"
+```
+
+---
+
+## 4. Temporarily disabling a plugin
+
+Set `enabled: false` on the pipeline stage. The stage stays in the file so you
+can re-enable it without rewriting the config.
+
+```yaml
+pipeline:
+  - plugin: embed_fallback_translations
+    enabled: false   # temporarily disabled
+```
+
+Previously, removing the top-level key was the only way to disable a plugin.
+
+---
+
+## 5. Running the same plugin more than once
+
+The pipeline allows the same plugin to appear multiple times with different
+options. This was not possible with the old top-level key approach.
+
+```yaml
+pipeline:
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: templates/esm.erb
+        output: "%{dir}/%{base_name}.mjs"
+
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: templates/cjs.erb
+        output: "%{dir}/%{base_name}.cjs"
+```
+
+---
+
+## 6. The `check` key was removed
+
+The `check:` root key is no longer a recognised configuration option and will
+cause a validation error if present. Remove it from your config file.
+
+**Before**
+
+```yaml
+check:
+  ignore:
+    - "es.bye"
+    - "pt.bye"
+```
+
+**After** — delete the `check:` block entirely. There is no replacement in the
+current version.
+
+---
+
+## Quick checklist
+
+- [ ] Remove the top-level `embed_fallback_translations:` block and replace with a `pipeline:` entry
+- [ ] Remove the top-level `export_files:` block and replace with a `pipeline:` entry (move `files:` into the stage)
+- [ ] Do the same for any third-party plugin that had its own top-level key
+- [ ] Remove the `check:` block if present
+- [ ] Verify the `pipeline:` key is a YAML sequence (starts with `-`), not a mapping

--- a/MIGRATING_CONFIG_FOR_USERS.md
+++ b/MIGRATING_CONFIG_FOR_USERS.md
@@ -165,7 +165,9 @@ pipeline:
 ## 6. The `check` key was removed
 
 The `check:` root key is no longer a recognised configuration option and will
-cause a validation error if present. Remove it from your config file.
+cause a validation error if present. If you used `check.ignore` to suppress
+known-missing translation keys, move those entries to `lint_translations.ignore`
+— it serves the same purpose.
 
 **Before**
 
@@ -176,8 +178,16 @@ check:
     - "pt.bye"
 ```
 
-**After** — delete the `check:` block entirely. There is no replacement in the
-current version.
+**After**
+
+```yaml
+lint_translations:
+  ignore:
+    - "es.bye"
+    - "pt.bye"
+```
+
+If your `check:` block contained no `ignore:` list, delete it entirely.
 
 ---
 
@@ -186,5 +196,5 @@ current version.
 - [ ] Remove the top-level `embed_fallback_translations:` block and replace with a `pipeline:` entry
 - [ ] Remove the top-level `export_files:` block and replace with a `pipeline:` entry (move `files:` into the stage)
 - [ ] Do the same for any third-party plugin that had its own top-level key
-- [ ] Remove the `check:` block if present
+- [ ] Move `check.ignore` entries to `lint_translations.ignore`, then delete the `check:` block
 - [ ] Verify the `pipeline:` key is a YAML sequence (starts with `-`), not a mapping

--- a/MIGRATING_PLUGINS_FOR_PLUGIN_DEVELOPERS.md
+++ b/MIGRATING_PLUGINS_FOR_PLUGIN_DEVELOPERS.md
@@ -1,0 +1,299 @@
+# Migrating Plugins to the Pipeline API
+
+This guide covers the breaking changes to the plugin API introduced in the
+commit that switched plugins from top-level config keys to a `pipeline` array.
+
+---
+
+## Overview of changes
+
+| Area | Before | After |
+|------|--------|-------|
+| Config location | Top-level key per plugin | `pipeline:` array |
+| Key method | `config_key` (instance, Symbol) | `Plugin.key` (class method, String) |
+| Constructor | `initialize(config:)` | `initialize(plugin_config:, main_config:)` |
+| `config` accessor | `main_config[config_key]` | plugin-specific hash from pipeline entry |
+| `setup` | registers root schema key | no schema registration needed |
+| `validate_schema` paths | prefixed with `config_key` | relative to plugin config root |
+| `I18nJS.plugins` | global accessor | return value of `initialize_plugins!` |
+| `Schema.root_keys` | mutable Set | frozen Array |
+
+---
+
+## 1. Update the config file
+
+Plugin configuration no longer lives at the top level of the YAML file. Move
+every plugin block into the `pipeline:` array and add a `plugin:` key that
+identifies the plugin by its inferred key name (snake_case, no `Plugin`
+suffix).
+
+**Before**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+embed_fallback_translations:
+  enabled: true
+
+export_files:
+  enabled: true
+  files:
+    - template: templates/export.erb
+      output: "%{dir}/%{base_name}-%{digest}.ts"
+```
+
+**After**
+
+```yaml
+translations:
+  - file: app/javascript/locales/%{locale}.json
+    patterns:
+      - "*"
+
+pipeline:
+  - plugin: embed_fallback_translations
+    enabled: true
+
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: templates/export.erb
+        output: "%{dir}/%{base_name}-%{digest}.ts"
+```
+
+All plugin-specific keys (like `files:` above) now live directly inside the
+pipeline stage object, alongside `plugin:` and `enabled:`.
+
+---
+
+## 2. Rename `config_key` to `Plugin.key`
+
+The method that infers the plugin's identifier moved from an **instance**
+method returning a Symbol to a **class** method returning a String.
+
+**Before**
+
+```ruby
+# instance method, returns Symbol
+def config_key
+  :my_plugin
+end
+```
+
+**After**
+
+```ruby
+# class method, returns String
+def self.key
+  "my_plugin"
+end
+```
+
+In most cases you do **not** need to override this method at all — it is
+automatically inferred from the class name:
+
+| Class name | Inferred key |
+|------------|-------------|
+| `SamplePlugin` | `"sample"` |
+| `EmbedFallbackTranslationsPlugin` | `"embed_fallback_translations"` |
+| `FetchFromHTTPPlugin` | `"fetch_from_http"` |
+
+Override only if the inferred name does not match what you want to expose in the
+config file.
+
+---
+
+## 3. Update the constructor
+
+The constructor signature changed. `config:` (the full main config) was
+replaced by two keyword arguments.
+
+**Before**
+
+```ruby
+def initialize(config:)
+  @main_config = config
+  @schema      = I18nJS::Schema.new(@main_config)
+end
+```
+
+**After**
+
+The base class handles initialization. You rarely need to override `initialize`
+at all. If you do, call `super` and use the provided accessors:
+
+```ruby
+def initialize(plugin_config:, main_config:)
+  super
+  # @config      => plugin-specific hash (the pipeline stage, minus :plugin key)
+  # @main_config => full config hash
+  # @schema      => Schema.new(@config)
+end
+```
+
+---
+
+## 4. Use `config` instead of `main_config[config_key]`
+
+`config` now returns only the plugin's own slice of configuration (the pipeline
+stage hash, with the `plugin:` key removed). You no longer need to dig into
+`main_config` to find your plugin's settings.
+
+**Before**
+
+```ruby
+def transform(translations:)
+  return translations unless main_config[config_key][:enabled]
+  # work with main_config[config_key][:my_option]
+end
+```
+
+**After**
+
+```ruby
+def transform(translations:)
+  # work with config[:my_option] directly
+end
+```
+
+`enabled?` is also handled by the base class and returns `config[:enabled]`.
+Only enabled plugins are placed in the pipeline, so you rarely need to check
+`enabled?` inside `transform`.
+
+---
+
+## 5. Remove schema root key registration from `setup`
+
+Plugins used to register their top-level config key so the schema validator
+wouldn't reject it. This is no longer necessary — the `pipeline:` array is
+already a recognised root key, and each stage is validated generically.
+
+**Before**
+
+```ruby
+def setup
+  I18nJS::Schema.root_keys << config_key
+end
+```
+
+**After**
+
+```ruby
+def setup
+  # plugin-specific setup only, no schema registration needed
+end
+```
+
+If `setup` contained only the `root_keys <<` line, you can delete the method
+entirely.
+
+---
+
+## 6. Update `validate_schema` paths
+
+`Schema` is now initialized with the plugin's own config hash rather than the
+full main config. All paths passed to schema helpers are therefore **relative to
+the plugin config root**, not the global config root.
+
+**Before**
+
+```ruby
+def validate_schema
+  valid_keys = %i[enabled files]
+
+  schema.expect_required_keys(keys: valid_keys, path: [config_key])
+  schema.reject_extraneous_keys(keys: valid_keys, path: [config_key])
+  schema.expect_array_with_items(path: [config_key, :files])
+
+  config[:files].each_with_index do |_, index|
+    export_keys = %i[template output]
+    schema.expect_required_keys(keys: export_keys, path: [config_key, :files, index])
+    schema.expect_type(path: [config_key, :files, index, :template], types: String)
+  end
+end
+```
+
+**After**
+
+```ruby
+def validate_schema
+  valid_keys = %i[enabled files]
+
+  schema.expect_required_keys(keys: valid_keys)          # path defaults to []
+  schema.reject_extraneous_keys(keys: valid_keys)
+  schema.expect_array_with_items(path: [:files])         # relative path
+
+  export_keys = %i[template output]
+  config[:files].each_with_index do |_, index|
+    schema.expect_required_keys(keys: export_keys, path: [:files, index])
+    schema.expect_type(path: [:files, index, :template], types: String)
+  end
+end
+```
+
+The rule: **drop the leading `config_key` segment from every path**.
+
+---
+
+## 7. Stop using `I18nJS.plugins`
+
+The global `I18nJS.plugins` accessor was removed. `initialize_plugins!` now
+returns the list of active plugin instances directly.
+
+**Before**
+
+```ruby
+I18nJS.initialize_plugins!(config:)
+I18nJS.plugins.each { |p| p.do_something }
+```
+
+**After**
+
+```ruby
+plugins = I18nJS.initialize_plugins!(config:)
+plugins.each { |p| p.do_something }
+```
+
+If you were calling `I18nJS.plugins.clear` in tests, switch to
+`I18nJS.available_plugins.clear` (which clears registered plugin classes) or
+simply stop clearing — `initialize_plugins!` now reads solely from the
+`pipeline:` config so stale instances are never carried over.
+
+---
+
+## 8. One plugin class, multiple pipeline stages
+
+A single plugin class can now appear **multiple times** in the pipeline with
+different configurations. Each entry creates an independent plugin instance.
+Each instance receives its own `config` hash.
+
+```yaml
+pipeline:
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: templates/esm.erb
+        output: "app/js/%{base_name}.mjs"
+
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: templates/cjs.erb
+        output: "app/js/%{base_name}.cjs"
+```
+
+---
+
+## Quick checklist
+
+- [ ] Move all plugin blocks from the top level into a `pipeline:` array
+- [ ] Add a `plugin:` key to each pipeline stage
+- [ ] Rename `config_key` instance method to `self.key` class method; change return type from Symbol to String
+- [ ] Remove `initialize` override if it only delegated to `super`; otherwise update signature to `(plugin_config:, main_config:)`
+- [ ] Replace `main_config[config_key][:option]` with `config[:option]`
+- [ ] Delete `setup` if it only registered a root schema key
+- [ ] Drop the leading `config_key` segment from all `schema.*` paths in `validate_schema`
+- [ ] Replace `I18nJS.plugins` with the return value of `initialize_plugins!`

--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ To use it, add the following to your configuration file:
 
 ```yaml
 ---
-embed_fallback_translations:
-  enabled: true
+pipeline:
+  - plugin: embed_fallback_translations
+    enabled: true
 ```
 
 ##### `export_files`:
@@ -173,11 +174,12 @@ configuration file:
 
 ```yaml
 ---
-export_files:
-  enabled: true
-  files:
-    - template: path/to/template.erb
-      output: "%{dir}/%{base_name}.ts"
+pipeline:
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: path/to/template.erb
+        output: "%{dir}/%{base_name}.ts"
 ```
 
 You can export multiple files by defining more entries.
@@ -235,8 +237,8 @@ i18n.store({
 #### Plugin API
 
 You can transform the exported translations by adding plugins. A plugin must
-inherit from `I18nJS::Plugin` and can have 4 class methods (they're all optional
-and will default to a noop implementation). For real examples, see
+inherit from `I18nJS::Plugin` and can override 4 instance methods (they're all
+optional and default to a noop implementation). For real examples, see
 [lib/i18n-js/embed_fallback_translations_plugin.rb](https://github.com/fnando/i18n-js/blob/main/lib/i18n-js/embed_fallback_translations_plugin.rb)
 and
 [lib/i18n-js/export_files_plugin.rb](https://github.com/fnando/i18n-js/blob/main/lib/i18n-js/export_files_plugin.rb)
@@ -247,7 +249,7 @@ and
 module I18nJS
   class SamplePlugin < I18nJS::Plugin
     # This method is responsible for transforming the translations. The
-    # translations you'll receive may be already be filtered by other plugins
+    # translations you'll receive may already be filtered by other plugins
     # and by the default filtering itself. If you need to access the original
     # translations, use `I18nJS.translations`.
     def transform(translations:)
@@ -257,26 +259,17 @@ module I18nJS
     end
 
     # In case your plugin accepts configuration, this is where you must validate
-    # the configuration, making sure only valid keys and type is provided.
-    # If the configuration contains invalid data, then you must raise an
-    # exception using something like
+    # it, making sure only valid keys and types are provided.
+    # If the configuration contains invalid data, raise an exception using
     # `raise I18nJS::Schema::InvalidError, error_message`.
-    #
-    # Notice the validation will only happen when the plugin configuration is
-    # set (i.e. the configuration contains your config key).
+    # Paths passed to schema helpers are relative to the plugin's own config
+    # root (i.e. the pipeline stage object, minus the `plugin:` key).
     def validate_schema
       # validate plugin schema here…
     end
 
-    # This method must set up the basic plugin configuration, like adding the
-    # config's root key in case your plugin accepts configuration (defined via
-    # the config file).
-    #
-    # If you don't add this key, the linter will prevent non-default keys from
-    # being added to the configuration file.
+    # Called after schema validation. Use this for any one-time plugin setup.
     def setup
-      # If you plugin has configuration, uncomment the line below
-      # I18nJS::Schema.root_keys << config_key
     end
 
     # This method is called whenever `I18nJS.call(**kwargs)` finishes exporting
@@ -291,20 +284,32 @@ module I18nJS
 end
 ```
 
-The class `I18nJS::Plugin` implements some helper methods that you can use:
+The class `I18nJS::Plugin` exposes the following helpers:
 
-- `I18nJS::Plugin#config_key`: the configuration key that was inferred out of
-  your plugin's class name.
-- `I18nJS::Plugin#config`: the plugin configuration.
-- `I18nJS::Plugin#enabled?`: whether the plugin is enabled or not based on the
-  plugin's configuration.
+- `I18nJS::Plugin.key`: the configuration key inferred from your plugin's class
+  name (e.g. `SamplePlugin` → `"sample"`). Override this class method to use a
+  custom key.
+- `I18nJS::Plugin#config`: the plugin's own configuration hash (the pipeline
+  stage entry, minus the `plugin:` key).
+- `I18nJS::Plugin#main_config`: the full i18n-js configuration hash.
+- `I18nJS::Plugin#enabled?`: whether the plugin is enabled based on
+  `config[:enabled]`.
 
-To distribute this plugin, you need to create a gem package that matches the
-pattern `i18n-js/*_plugin.rb`. You can test whether your plugin will be found by
-installing your gem, opening a iRB session and running
-`Gem.find_files("i18n-js/*_plugin.rb")`. If your plugin is not listed, then you
-need to double check your gem load path and see why the file is not being
-loaded.
+Plugins are configured via the `pipeline:` array in the config file. Each entry
+must have a `plugin:` key matching `Plugin.key` and an `enabled:` boolean. Any
+additional keys in the stage are passed to the plugin as part of `config`.
+
+```yaml
+pipeline:
+  - plugin: sample
+    enabled: true
+    my_option: value
+```
+
+To distribute a plugin, create a gem whose load path contains a file matching
+the pattern `i18n-js/*_plugin.rb`. You can verify it will be found by running
+`Gem.find_files("i18n-js/*_plugin.rb")` in an IRB session after installing
+your gem.
 
 ### Listing missing translations
 

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -27,8 +27,8 @@ module I18nJS
     config = Glob::SymbolizeKeys.call(config || load_config_file(config_file))
 
     load_plugins!
-    plugins = initialize_plugins!(config:)
     Schema.validate!(config)
+    plugins = initialize_plugins!(config:)
 
     exported_files = []
 

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -28,7 +28,7 @@ module I18nJS
 
     load_plugins!
     Schema.validate!(config)
-    plugins = initialize_plugins!(config:)
+    plugins = initialize_plugins!(config)
 
     exported_files = []
 

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -27,12 +27,14 @@ module I18nJS
     config = Glob::SymbolizeKeys.call(config || load_config_file(config_file))
 
     load_plugins!
-    initialize_plugins!(config:)
+    plugins = initialize_plugins!(config:)
     Schema.validate!(config)
 
     exported_files = []
 
-    config[:translations].each {|group| exported_files += export_group(group) }
+    config[:translations].each do |group|
+      exported_files += export_group(group:, plugins:)
+    end
 
     plugins.each do |plugin|
       plugin.after_export(files: exported_files.dup) if plugin.enabled?
@@ -41,15 +43,11 @@ module I18nJS
     exported_files
   end
 
-  def self.export_group(group)
+  def self.export_group(group:, plugins:)
     filtered_translations = Glob.filter(translations, group[:patterns])
     filtered_translations =
       plugins.reduce(filtered_translations) do |buffer, plugin|
-        if plugin.enabled?
-          plugin.transform(translations: buffer)
-        else
-          buffer
-        end
+        plugin.transform(translations: buffer)
       end
 
     filtered_translations = sort_hash(clean_hash(filtered_translations))

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -82,6 +82,7 @@ module I18nJS
         config = load_config_file(config_file)
         I18nJS.load_plugins!
         Schema.validate!(config)
+        I18nJS.initialize_plugins!(config:)
 
         load_require_file!(require_file) if require_file
 

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -81,7 +81,7 @@ module I18nJS
 
         config = load_config_file(config_file)
         I18nJS.load_plugins!
-        I18nJS.initialize_plugins!(config:)
+        plugins = I18nJS.initialize_plugins!(config:)
         Schema.validate!(config)
 
         load_require_file!(require_file) if require_file

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -81,7 +81,6 @@ module I18nJS
 
         config = load_config_file(config_file)
         I18nJS.load_plugins!
-        plugins = I18nJS.initialize_plugins!(config:)
         Schema.validate!(config)
 
         load_require_file!(require_file) if require_file

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -82,7 +82,7 @@ module I18nJS
         config = load_config_file(config_file)
         I18nJS.load_plugins!
         Schema.validate!(config)
-        I18nJS.initialize_plugins!(config:)
+        I18nJS.initialize_plugins!(config)
 
         load_require_file!(require_file) if require_file
 

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -69,7 +69,6 @@ module I18nJS
 
         config = load_config_file(config_file)
         I18nJS.load_plugins!
-        plugins = I18nJS.initialize_plugins!(config:)
         Schema.validate!(config)
 
         load_require_file!(require_file) if require_file

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -70,7 +70,7 @@ module I18nJS
         config = load_config_file(config_file)
         I18nJS.load_plugins!
         Schema.validate!(config)
-        I18nJS.initialize_plugins!(config:)
+        I18nJS.initialize_plugins!(config)
 
         load_require_file!(require_file) if require_file
 

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -69,7 +69,7 @@ module I18nJS
 
         config = load_config_file(config_file)
         I18nJS.load_plugins!
-        I18nJS.initialize_plugins!(config:)
+        plugins = I18nJS.initialize_plugins!(config:)
         Schema.validate!(config)
 
         load_require_file!(require_file) if require_file

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -70,6 +70,7 @@ module I18nJS
         config = load_config_file(config_file)
         I18nJS.load_plugins!
         Schema.validate!(config)
+        I18nJS.initialize_plugins!(config:)
 
         load_require_file!(require_file) if require_file
 

--- a/lib/i18n-js/embed_fallback_translations_plugin.rb
+++ b/lib/i18n-js/embed_fallback_translations_plugin.rb
@@ -35,15 +35,11 @@ module I18nJS
       end
     end
 
-    def setup
-      I18nJS::Schema.root_keys << config_key
-    end
-
     def validate_schema
       valid_keys = %i[enabled]
 
-      schema.expect_required_keys(keys: valid_keys, path: [config_key])
-      schema.reject_extraneous_keys(keys: valid_keys, path: [config_key])
+      schema.expect_required_keys(keys: valid_keys)
+      schema.reject_extraneous_keys(keys: valid_keys)
     end
 
     def transform(translations:)

--- a/lib/i18n-js/export_files_plugin.rb
+++ b/lib/i18n-js/export_files_plugin.rb
@@ -4,39 +4,20 @@ module I18nJS
   require "i18n-js/plugin"
 
   class ExportFilesPlugin < I18nJS::Plugin
-    def setup
-      I18nJS::Schema.root_keys << config_key
-    end
-
     def validate_schema
       valid_keys = %i[enabled files]
 
-      schema.expect_required_keys(keys: valid_keys, path: [config_key])
-      schema.reject_extraneous_keys(keys: valid_keys, path: [config_key])
-      schema.expect_array_with_items(path: [config_key, :files])
+      schema.expect_required_keys(keys: valid_keys)
+      schema.reject_extraneous_keys(keys: valid_keys)
+      schema.expect_array_with_items(path: [:files])
+
+      export_keys = %i[template output]
 
       config[:files].each_with_index do |_exports, index|
-        export_keys = %i[template output]
-
-        schema.expect_required_keys(
-          keys: export_keys,
-          path: [config_key, :files, index]
-        )
-
-        schema.reject_extraneous_keys(
-          keys: export_keys,
-          path: [config_key, :files, index]
-        )
-
-        schema.expect_type(
-          path: [config_key, :files, index, :template],
-          types: String
-        )
-
-        schema.expect_type(
-          path: [config_key, :files, index, :output],
-          types: String
-        )
+        schema.expect_required_keys(keys: export_keys, path: [:files, index])
+        schema.reject_extraneous_keys(keys: export_keys, path: [:files, index])
+        schema.expect_type(path: [:files, index, :template], types: String)
+        schema.expect_type(path: [:files, index, :output], types: String)
       end
     end
 

--- a/lib/i18n-js/plugin.rb
+++ b/lib/i18n-js/plugin.rb
@@ -15,7 +15,7 @@ module I18nJS
     Gem.find_files("i18n-js/*_plugin.rb")
   end
 
-  def self.initialize_plugins!(config:)
+  def self.initialize_plugins!(config)
     config.fetch(:pipeline, []).filter_map do |plugin_config|
       plugin_class = available_plugins.find do |klass|
         klass.key == plugin_config[:plugin]

--- a/lib/i18n-js/plugin.rb
+++ b/lib/i18n-js/plugin.rb
@@ -7,10 +7,6 @@ module I18nJS
     @available_plugins ||= Set.new
   end
 
-  def self.plugins
-    @plugins ||= []
-  end
-
   def self.register_plugin(plugin)
     available_plugins << plugin
   end
@@ -19,46 +15,55 @@ module I18nJS
     Gem.find_files("i18n-js/*_plugin.rb")
   end
 
+  def self.initialize_plugins!(config:)
+    config.fetch(:pipeline, []).filter_map do |plugin_config|
+      plugin_class = available_plugins.find do |klass|
+        klass.key == plugin_config[:plugin]
+      end
+
+      plugin_config = plugin_config.except(:plugin)
+      plugin = plugin_class.new(main_config: config, plugin_config:)
+
+      next unless plugin.enabled?
+
+      plugin.validate_schema
+      plugin.setup
+      plugin
+    end
+  end
+
   def self.load_plugins!
     plugin_files.each do |path|
       require path
     end
   end
 
-  def self.initialize_plugins!(config:)
-    @plugins = available_plugins.map do |plugin|
-      plugin.new(config:).tap(&:setup)
-    end
-  end
-
   class Plugin
-    # The configuration that's being used to export translations.
+    # The plugin's configuration.
+    attr_reader :config
+
+    # The main configuration, which holds translation setup for
+    # plugins that supports exporting.
     attr_reader :main_config
 
-    # The `I18nJS::Schema` instance that can be used to validate your plugin's
-    # configuration.
+    # The schema validator for the plugin.
     attr_reader :schema
-
-    def initialize(config:)
-      @main_config = config
-      @schema = I18nJS::Schema.new(@main_config)
-    end
 
     # Infer the config key name out of the class.
     # If you plugin is called `MySamplePlugin`, the key will be `my_sample`.
-    def config_key
-      self.class.name.split("::").last
+    def self.key
+      name.split("::").last
           .gsub(/Plugin$/, "")
           .gsub(/^([A-Z]+)([A-Z])/) { "#{$1.downcase}#{$2}" }
           .gsub(/^([A-Z]+)/) { $1.downcase }
           .gsub(/([A-Z]+)/m) { "_#{$1.downcase}" }
           .downcase
-          .to_sym
     end
 
-    # Return the plugin configuration
-    def config
-      main_config[config_key] || {}
+    def initialize(plugin_config:, main_config:)
+      @config = plugin_config
+      @main_config = main_config
+      @schema = Schema.new(config)
     end
 
     # Check whether plugin is enabled or not.

--- a/lib/i18n-js/plugin.rb
+++ b/lib/i18n-js/plugin.rb
@@ -21,6 +21,11 @@ module I18nJS
         klass.key == plugin_config[:plugin]
       end
 
+      unless plugin_class
+        raise I18nJS::Schema::InvalidError,
+              "Unknown plugin: #{plugin_config[:plugin].inspect}"
+      end
+
       plugin_config = plugin_config.except(:plugin)
       plugin = plugin_class.new(main_config: config, plugin_config:)
 

--- a/lib/i18n-js/schema.rb
+++ b/lib/i18n-js/schema.rb
@@ -94,7 +94,7 @@ module I18nJS
     def validate_pipeline
       expect_type(path: [:pipeline], types: Array)
 
-      target[:pipeline].each_with_index do |stage, index|
+      target[:pipeline].each_with_index do |_, index|
         expect_type(path: [:pipeline, index], types: Hash)
         expect_required_keys(
           path: [:pipeline, index],

--- a/lib/i18n-js/schema.rb
+++ b/lib/i18n-js/schema.rb
@@ -10,16 +10,16 @@ module I18nJS
     TRANSLATION_KEYS = %i[file patterns].freeze
 
     def self.root_keys
-      @root_keys ||= Set.new(%i[
+      @root_keys ||= %i[
         translations
-        lint_translations
         lint_scripts
-        check
-      ])
+        lint_translations
+        pipeline
+      ].freeze
     end
 
     def self.required_root_keys
-      @required_root_keys ||= Set.new(%i[translations])
+      @required_root_keys ||= %i[translations].freeze
     end
 
     def self.validate!(target)
@@ -48,22 +48,9 @@ module I18nJS
       )
 
       validate_translations
+      validate_pipeline if target.key?(:pipeline)
       validate_lint_translations
       validate_lint_scripts
-      validate_plugins
-    end
-
-    def validate_plugins
-      I18nJS.plugins.each do |plugin|
-        next unless target.key?(plugin.config_key)
-
-        expect_type(
-          path: [plugin.config_key, :enabled],
-          types: [TrueClass, FalseClass]
-        )
-
-        plugin.validate_schema
-      end
     end
 
     def validate_root
@@ -102,6 +89,23 @@ module I18nJS
       )
       expect_type(path: [key, :ignore], types: Array)
       expect_type(path: [key, :patterns], types: Array)
+    end
+
+    def validate_pipeline
+      expect_type(path: [:pipeline], types: Array)
+
+      target[:pipeline].each_with_index do |stage, index|
+        expect_type(path: [:pipeline, index], types: Hash)
+        expect_required_keys(
+          path: [:pipeline, index],
+          keys: %i[plugin enabled]
+        )
+        expect_type(path: [:pipeline, index, :plugin], types: String)
+        expect_type(
+          path: [:pipeline, index, :enabled],
+          types: [TrueClass, FalseClass]
+        )
+      end
     end
 
     def validate_translations
@@ -155,7 +159,7 @@ module I18nJS
       reject message, target
     end
 
-    def expect_array_with_items(path:)
+    def expect_array_with_items(path: [])
       expect_type(path:, types: Array)
 
       path = prepare_path(path:)
@@ -167,7 +171,7 @@ module I18nJS
              target
     end
 
-    def expect_required_keys(keys:, path:)
+    def expect_required_keys(keys:, path: [])
       path = prepare_path(path:)
       value = value_for(path:)
       actual_keys = value.keys.map(&:to_sym)
@@ -185,7 +189,7 @@ module I18nJS
       end
     end
 
-    def reject_extraneous_keys(keys:, path:)
+    def reject_extraneous_keys(keys:, path: [])
       path = prepare_path(path:)
       value = value_for(path:)
 
@@ -204,12 +208,12 @@ module I18nJS
              target
     end
 
-    def prepare_path(path:)
+    def prepare_path(path: [])
       path = path.to_s.split(".").map(&:to_sym) unless path.is_a?(Array)
       path
     end
 
-    def value_for(path:)
+    def value_for(path: [])
       path.empty? ? target : target.dig(*path)
     end
   end

--- a/test/config/embed_fallback_translations.yml
+++ b/test/config/embed_fallback_translations.yml
@@ -4,5 +4,6 @@ translations:
     patterns:
       - "*"
 
-embed_fallback_translations:
-  enabled: true
+pipeline:
+  - plugin: embed_fallback_translations
+    enabled: true

--- a/test/config/export_files.yml
+++ b/test/config/export_files.yml
@@ -4,8 +4,9 @@ translations:
     patterns:
       - "*"
 
-export_files:
-  enabled: true
-  files:
-    - template: test/fixtures/export_files.erb
-      output: "%{dir}/%{base_name}-%{digest}.ts"
+pipeline:
+  - plugin: export_files
+    enabled: true
+    files:
+      - template: test/fixtures/export_files.erb
+        output: "%{dir}/%{base_name}-%{digest}.ts"

--- a/test/i18n-js/export_files_plugin_test.rb
+++ b/test/i18n-js/export_files_plugin_test.rb
@@ -5,7 +5,6 @@ require "test_helper"
 class ExportScriptFilesPluginTest < Minitest::Test
   test "exports script files" do
     require "i18n-js/export_files_plugin"
-    I18nJS.plugins.clear
     I18nJS.register_plugin(I18nJS::ExportFilesPlugin)
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
 

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -164,10 +164,6 @@ class ExporterTest < Minitest::Test
         "SamplePlugin"
       end
 
-      def setup
-        I18nJS::Schema.root_keys << config_key
-      end
-
       def transform(translations:)
         translations.each_key do |locale|
           translations[locale][:injected] = "yes:#{locale}"
@@ -178,8 +174,9 @@ class ExporterTest < Minitest::Test
     end
 
     config = Glob::SymbolizeKeys.call(
-      I18nJS.load_config_file("./test/config/everything.yml")
-        .merge(sample: {enabled: true})
+      I18nJS
+        .load_config_file("./test/config/everything.yml")
+        .merge(pipeline: [{plugin: "sample", enabled: true}])
     )
     I18nJS.register_plugin(plugin_class)
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]

--- a/test/i18n-js/plugin_test.rb
+++ b/test/i18n-js/plugin_test.rb
@@ -62,9 +62,7 @@ class PluginTest < Minitest::Test
     end
 
     I18nJS.register_plugin(plugin_class)
-    I18nJS.initialize_plugins!(
-      config: {pipeline: [{plugin: "sample", enabled: false}]}
-    )
+    I18nJS.initialize_plugins!(pipeline: [{plugin: "sample", enabled: false}])
 
     refute plugin_class.called
   end

--- a/test/i18n-js/plugin_test.rb
+++ b/test/i18n-js/plugin_test.rb
@@ -45,9 +45,7 @@ class PluginTest < Minitest::Test
     end
 
     I18nJS.register_plugin(plugin_class)
-    I18nJS.initialize_plugins!(
-      config: {pipeline: [{plugin: "sample", enabled: true}]}
-    )
+    I18nJS.initialize_plugins!(pipeline: [{plugin: "sample", enabled: true}])
 
     assert plugin_class.called
   end
@@ -91,7 +89,7 @@ class PluginTest < Minitest::Test
     end
 
     I18nJS.register_plugin(plugin_class)
-    I18nJS.initialize_plugins!(config:)
+    I18nJS.initialize_plugins!(config)
 
     assert_equal 1, plugin_class.calls.size
     assert_includes plugin_class.calls, :validated_schema
@@ -108,13 +106,11 @@ class PluginTest < Minitest::Test
 
     I18nJS.register_plugin(plugin_class)
     plugins = I18nJS.initialize_plugins!(
-      config: {
-        pipeline: [
-          {plugin: "sample", enabled: true, index: 0},
-          {plugin: "sample", enabled: true, index: 1},
-          {plugin: "sample", enabled: false, index: 2}
-        ]
-      }
+      pipeline: [
+        {plugin: "sample", enabled: true, index: 0},
+        {plugin: "sample", enabled: true, index: 1},
+        {plugin: "sample", enabled: false, index: 2}
+      ]
     )
 
     assert_equal 2, plugins.size
@@ -148,9 +144,7 @@ class PluginTest < Minitest::Test
     end
 
     I18nJS.register_plugin(plugin_class)
-
-    actual_files =
-      I18nJS.call(config:)
+    actual_files = I18nJS.call(config:)
 
     assert_exported_files expected_files, actual_files
     assert_exported_files expected_files, plugin_class.received_files
@@ -158,9 +152,7 @@ class PluginTest < Minitest::Test
 
   test "raises error for unknown plugin name" do
     error = assert_raises(I18nJS::Schema::InvalidError) do
-      I18nJS.initialize_plugins!(
-        config: {pipeline: [{plugin: "unknown", enabled: true}]}
-      )
+      I18nJS.initialize_plugins!(pipeline: [{plugin: "unknown", enabled: true}])
     end
 
     assert_match "Unknown plugin: \"unknown\"", error.message

--- a/test/i18n-js/plugin_test.rb
+++ b/test/i18n-js/plugin_test.rb
@@ -91,8 +91,7 @@ class PluginTest < Minitest::Test
     end
 
     I18nJS.register_plugin(plugin_class)
-    plugins = I18nJS.initialize_plugins!(config:)
-    I18nJS::Schema.validate!(config)
+    I18nJS.initialize_plugins!(config:)
 
     assert_equal 1, plugin_class.calls.size
     assert_includes plugin_class.calls, :validated_schema
@@ -113,7 +112,7 @@ class PluginTest < Minitest::Test
         pipeline: [
           {plugin: "sample", enabled: true, index: 0},
           {plugin: "sample", enabled: true, index: 1},
-          {plugin: "sample", enabled: false, index: 2},
+          {plugin: "sample", enabled: false, index: 2}
         ]
       }
     )

--- a/test/i18n-js/plugin_test.rb
+++ b/test/i18n-js/plugin_test.rb
@@ -156,6 +156,16 @@ class PluginTest < Minitest::Test
     assert_exported_files expected_files, plugin_class.received_files
   end
 
+  test "raises error for unknown plugin name" do
+    error = assert_raises(I18nJS::Schema::InvalidError) do
+      I18nJS.initialize_plugins!(
+        config: {pipeline: [{plugin: "unknown", enabled: true}]}
+      )
+    end
+
+    assert_match "Unknown plugin: \"unknown\"", error.message
+  end
+
   test "loads plugins using rubygems" do
     Gem
       .expects(:find_files)

--- a/test/i18n-js/plugin_test.rb
+++ b/test/i18n-js/plugin_test.rb
@@ -19,7 +19,7 @@ class PluginTest < Minitest::Test
 
   test "implements default transform method" do
     plugin_class = create_plugin
-    plugin = plugin_class.new(config: {})
+    plugin = plugin_class.new(main_config: {}, plugin_config: {})
     translations = {}
 
     assert_same translations,
@@ -35,15 +35,40 @@ class PluginTest < Minitest::Test
 
   test "setups plugin" do
     plugin_class = create_plugin do
+      class << self
+        attr_accessor :called
+      end
+
       def setup
-        I18nJS::Schema.root_keys << :sample
+        self.class.called = true
       end
     end
 
     I18nJS.register_plugin(plugin_class)
-    I18nJS.initialize_plugins!(config: {})
+    I18nJS.initialize_plugins!(
+      config: {pipeline: [{plugin: "sample", enabled: true}]}
+    )
 
-    assert_includes I18nJS::Schema.root_keys, :sample
+    assert plugin_class.called
+  end
+
+  test "skips setup for disabled plugin" do
+    plugin_class = create_plugin do
+      class << self
+        attr_accessor :called
+      end
+
+      def setup
+        self.class.called = true
+      end
+    end
+
+    I18nJS.register_plugin(plugin_class)
+    I18nJS.initialize_plugins!(
+      config: {pipeline: [{plugin: "sample", enabled: false}]}
+    )
+
+    refute plugin_class.called
   end
 
   test "validates schema" do
@@ -56,33 +81,54 @@ class PluginTest < Minitest::Test
           ]
         }
       ],
-      sample: {
-        enabled: true
-      }
+      pipeline: [{plugin: "sample", enabled: true}]
     }
 
     plugin_class = create_plugin do
-      def setup
-        I18nJS::Schema.root_keys << config_key
-      end
-
       def validate_schema
         self.class.calls << :validated_schema
       end
     end
 
     I18nJS.register_plugin(plugin_class)
-    I18nJS.initialize_plugins!(config:)
+    plugins = I18nJS.initialize_plugins!(config:)
     I18nJS::Schema.validate!(config)
 
     assert_equal 1, plugin_class.calls.size
     assert_includes plugin_class.calls, :validated_schema
   end
 
+  test "runs sample plugin class more than once" do
+    plugin_class = create_plugin do
+      attr_accessor :called
+
+      def setup
+        self.called = true
+      end
+    end
+
+    I18nJS.register_plugin(plugin_class)
+    plugins = I18nJS.initialize_plugins!(
+      config: {
+        pipeline: [
+          {plugin: "sample", enabled: true, index: 0},
+          {plugin: "sample", enabled: true, index: 1},
+          {plugin: "sample", enabled: false, index: 2},
+        ]
+      }
+    )
+
+    assert_equal 2, plugins.size
+    assert plugins.all?(&:called)
+    assert_equal 0, plugins[0].config[:index]
+    assert_equal 1, plugins[1].config[:index]
+  end
+
   test "runs after_export event" do
     config = Glob::SymbolizeKeys.call(
-      I18nJS.load_config_file("./test/config/locale_placeholder.yml")
-        .merge(sample: {enabled: true})
+      I18nJS
+        .load_config_file("./test/config/locale_placeholder.yml")
+        .merge(pipeline: [{plugin: "sample", enabled: true}])
     )
 
     I18n.load_path << Dir["./test/fixtures/yml/*.yml"]
@@ -95,10 +141,6 @@ class PluginTest < Minitest::Test
     plugin_class = create_plugin do
       class << self
         attr_accessor :received_config, :received_files
-      end
-
-      def setup
-        I18nJS::Schema.root_keys << :sample
       end
 
       def after_export(files:)
@@ -128,17 +170,16 @@ class PluginTest < Minitest::Test
 
   test "infers config key out of class name" do
     {
-      "SamplePlugin" => :sample,
-      "EmbedFallbackTranslationsPlugin" => :embed_fallback_translations,
-      "ExportFilesPlugin" => :export_files,
-      "FetchFromHTTPPlugin" => :fetch_from_http,
-      "HTTPClientPlugin" => :http_client
+      "SamplePlugin" => "sample",
+      "EmbedFallbackTranslationsPlugin" => "embed_fallback_translations",
+      "ExportFilesPlugin" => "export_files",
+      "FetchFromHTTPPlugin" => "fetch_from_http",
+      "HTTPClientPlugin" => "http_client"
     }.each do |class_name, key|
       plugin_class = Class.new(I18nJS::Plugin)
       plugin_class.stubs(:name).returns(class_name)
-      plugin = plugin_class.new(config: {})
 
-      assert_equal key, plugin.config_key
+      assert_equal key, plugin_class.key
     end
   end
 end

--- a/test/i18n-js/schema_test.rb
+++ b/test/i18n-js/schema_test.rb
@@ -33,8 +33,10 @@ class SchemaTest < Minitest::Test
   test "rejects extraneous keys on root" do
     assert_schema_error("config has unexpected keys: [:foo]") do
       I18nJS::Schema.validate!(
-        translations: [{file: "file.json", patterns: ["*"]}],
-        foo: 1
+        {
+          translations: [{file: "file.json", patterns: ["*"]}],
+          foo: 1
+        }
       )
     end
   end
@@ -47,13 +49,22 @@ class SchemaTest < Minitest::Test
     end
   end
 
+  test "requires pipeline key to be an array" do
+    assert_schema_error(
+      %[Expected "pipeline" to be "Array"; got Hash instead]
+    ) do
+      I18nJS::Schema.validate!(
+        translations: [{file: "file.json", patterns: ["*"]}],
+        pipeline: {}
+      )
+    end
+  end
+
   test "requires at least one translation config" do
     error_message = "Expected \"translations\" to have at least one item"
 
     assert_schema_error(error_message) do
-      I18nJS::Schema.validate!(
-        translations: []
-      )
+      I18nJS::Schema.validate!(translations: [])
     end
   end
 
@@ -61,9 +72,7 @@ class SchemaTest < Minitest::Test
     error_message = "Expected \"translations.0.file\" to be defined"
 
     assert_schema_error(error_message) do
-      I18nJS::Schema.validate!(
-        translations: [{patterns: "*"}]
-      )
+      I18nJS::Schema.validate!(translations: [{patterns: "*"}])
     end
   end
 
@@ -72,9 +81,7 @@ class SchemaTest < Minitest::Test
                     "got NilClass instead"
 
     assert_schema_error(error_message) do
-      I18nJS::Schema.validate!(
-        translations: [{file: nil, patterns: "*"}]
-      )
+      I18nJS::Schema.validate!(translations: [{file: nil, patterns: "*"}])
     end
   end
 
@@ -82,9 +89,7 @@ class SchemaTest < Minitest::Test
     error_message = "Expected \"translations.0.patterns\" to be defined"
 
     assert_schema_error(error_message) do
-      I18nJS::Schema.validate!(
-        translations: [{file: "some/file.json"}]
-      )
+      I18nJS::Schema.validate!(translations: [{file: "some/file.json"}])
     end
   end
 
@@ -180,26 +185,20 @@ class SchemaTest < Minitest::Test
           ]
         }
       ],
-      sample: {
-        enabled: nil
-      }
+      pipeline: [{plugin: "sample", enabled: nil}]
     }
 
     plugin_class = Class.new(I18nJS::Plugin) do
       def self.name
         "SamplePlugin"
       end
-
-      def setup
-        I18nJS::Schema.root_keys << :sample
-      end
     end
 
     I18nJS.register_plugin(plugin_class)
-    I18nJS.initialize_plugins!(config:)
+    plugins = I18nJS.initialize_plugins!(config:)
 
     error_message =
-      "Expected \"sample.enabled\" to be one of [TrueClass, FalseClass]; " \
+      "Expected \"pipeline.0.enabled\" to be one of [TrueClass, FalseClass]; " \
       "got NilClass instead"
 
     assert_schema_error(error_message) do

--- a/test/i18n-js/schema_test.rb
+++ b/test/i18n-js/schema_test.rb
@@ -195,7 +195,6 @@ class SchemaTest < Minitest::Test
     end
 
     I18nJS.register_plugin(plugin_class)
-    plugins = I18nJS.initialize_plugins!(config:)
 
     error_message =
       "Expected \"pipeline.0.enabled\" to be one of [TrueClass, FalseClass]; " \

--- a/test/support/minitest.rb
+++ b/test/support/minitest.rb
@@ -7,11 +7,9 @@ module Minitest
     setup do
       reset_i18n
 
-      I18nJS.plugins.clear
       I18nJS.available_plugins.clear
       I18n.config.clear_available_locales_set
       I18n.backend = I18n::Backend::Simple.new
-      I18nJS::Schema.root_keys.delete(:sample)
       FileUtils.rm_rf "./test/output"
     end
 


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Plugin configuration has been moved from top-level keys in the config file (e.g. `embed_fallback_translations:`, `export_files:`) to a unified `pipeline:` array. Each entry in the array carries a `plugin:` identifier, an `enabled:` flag, and any plugin-specific options inline.

The plugin Ruby API changed accordingly: `config_key` (instance method, Symbol) is replaced by `Plugin.key` (class method, String); the constructor signature changed from `initialize(config:)` to `initialize(plugin_config:, main_config:)`; `config` now returns only the plugin's own slice; `Schema.root_keys` is frozen and plugins no longer register their root key in `setup`; `validate_schema` paths are relative to the plugin config root; and `I18nJS.plugins` is removed in favour of the return value of `initialize_plugins!`. The `check:` root key has been removed from the schema. A single plugin class can now appear multiple times in the pipeline with different configurations.

### Why

Centralising all plugin configuration under `pipeline:` makes execution order explicit and enables running the same plugin class more than once with different options — something the old per-key approach couldn't support.

### Known limitations

N/A