### PR TITLE
Use the missing translations count instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Prefix your message with one of the following:
 
 ## Unreleased
 
+- [Fixed] Return the number of missing translations as the exit code when
+  running `i18n lint:scripts`.
 - [Changed] Plugin configuration moved from top-level keys to a `pipeline:`
   array in the config file. Each entry requires a `plugin:` key identifying the
   plugin and an `enabled:` key. Plugin-specific options are defined inline in
@@ -26,11 +28,11 @@ Prefix your message with one of the following:
   configuration slice instead of the full main config.
 - [Changed] `I18nJS.initialize_plugins!` now returns the list of active plugin
   instances. The `I18nJS.plugins` accessor has been removed.
-- [Changed] `I18nJS::Schema.root_keys` is now a frozen Array. Plugins no
-  longer need to register a root key in their `setup` method.
-- [Changed] Schema validation paths in `validate_schema` are now relative to
-  the plugin's own config root. Remove the leading `config_key` segment from
-  all paths passed to `schema.*` helpers.
+- [Changed] `I18nJS::Schema.root_keys` is now a frozen Array. Plugins no longer
+  need to register a root key in their `setup` method.
+- [Changed] Schema validation paths in `validate_schema` are now relative to the
+  plugin's own config root. Remove the leading `config_key` segment from all
+  paths passed to `schema.*` helpers.
 - [Removed] The `check:` root key is no longer recognised by the schema
   validator. Remove it from your config file.
 - [Added] A single plugin class can now appear multiple times in the pipeline

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -137,7 +137,7 @@ module I18nJS
                         "missing, #{ignored_count} ignored"
         ui.stdout_print messages.sort.join("\n")
 
-        exit(missing_count.size)
+        exit(missing_count)
       end
 
       private def set_defaults!

--- a/test/i18n-js/cli/lint_scripts_command_test.rb
+++ b/test/i18n-js/cli/lint_scripts_command_test.rb
@@ -108,7 +108,7 @@ class LintCommandTest < Minitest::Test
       stderr:
     )
 
-    assert_exit_code(8) { cli.call }
+    assert_exit_code(11) { cli.call }
 
     output = format(
       File.read("./test/fixtures/expected/lint.txt"),


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [ ] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Use the number of missing translations as the exit code when running `i18n lint:scripts`.

### Why

Fix #738.

### Known limitations

N/A
