### PR TITLE
Allow lint's ignore to have globs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Prefix your message with one of the following:
 
 ## Unreleased
 
+- [Changed] `i18n lint:translations` and `i18n lint:scripts` now support globs
+  in their `ignore` option.
 - [Removed] Remove `i18n check`; use `i18n lint:translations` instead.
 - [Fixed] Return the number of missing translations as the exit code when
   running `i18n lint:scripts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Prefix your message with one of the following:
 
 - [Changed] `i18n lint:translations` and `i18n lint:scripts` now support globs
   in their `ignore` option.
+- [Removed] Previous versions allowed bare keys in lint's `:ignore` rule. This
+  is no longer support; instead, use `*.key`.
 - [Removed] Remove `i18n check`; use `i18n lint:translations` instead.
 - [Fixed] Return the number of missing translations as the exit code when
   running `i18n lint:scripts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Prefix your message with one of the following:
 - [Changed] `i18n lint:translations` and `i18n lint:scripts` now support globs
   in their `ignore` option.
 - [Removed] Previous versions allowed bare keys in lint's `:ignore` rule. This
-  is no longer support; instead, use `*.key`.
+  is no longer supported; instead, use `*.key`.
 - [Removed] Remove `i18n check`; use `i18n lint:translations` instead.
 - [Fixed] Return the number of missing translations as the exit code when
   running `i18n lint:scripts`.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ $ i18n lint:translations
    - pt-BR.github.repository (extraneous)
 ```
 
-This command will exit with status 1 whenever there are missing translations.
+This command will `exit(missing_count)` whenever there are missing translations.
 This way you can use it as a CI linting tool.
 
 You can ignore keys by adding a list to the config file:

--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ pipeline:
 
 To distribute a plugin, create a gem whose load path contains a file matching
 the pattern `i18n-js/*_plugin.rb`. You can verify it will be found by running
-`Gem.find_files("i18n-js/*_plugin.rb")` in an IRB session after installing
-your gem.
+`Gem.find_files("i18n-js/*_plugin.rb")` in an IRB session after installing your
+gem.
 
 ### Listing missing translations
 
@@ -354,15 +354,9 @@ translations:
 
 lint_translations:
   ignore:
-    - en.mailer.login.subject
-    - en.mailer.login.body
+    - "*.mailer.login.subject"
+    - "*.mailer.login.body"
 ```
-
-> [!NOTE]
->
-> In order to avoid mistakenly ignoring keys, this configuration option only
-> accepts the full translation scope, rather than accepting a pattern like
-> `pt.ignored.scope.*`.
 
 ### Linting your JavaScript/TypeScript files
 
@@ -422,7 +416,7 @@ translations:
 
 lint_scripts:
   ignore:
-    - ignore_scope # will ignore this scope on all languages
+    - "*.ignore_scope" # will ignore this scope on all languages
     - pt.another_ignore_scope # will ignore this scope only on `pt`
 ```
 

--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -12,6 +12,7 @@ require "digest/md5"
 require_relative "i18n-js/schema"
 require_relative "i18n-js/version"
 require_relative "i18n-js/plugin"
+require_relative "i18n-js/deep_merge"
 require_relative "i18n-js/sort_hash"
 require_relative "i18n-js/clean_hash"
 

--- a/lib/i18n-js/cli/command.rb
+++ b/lib/i18n-js/cli/command.rb
@@ -40,13 +40,7 @@ module I18nJS
       end
 
       private def load_config_file(config_file)
-        config = Glob::SymbolizeKeys.call(YAML.load_file(config_file))
-
-        if config.key?(:check)
-          config[:lint_translations] ||= config.delete(:check)
-        end
-
-        config
+        Glob::SymbolizeKeys.call(YAML.load_file(config_file))
       end
 
       private def load_require_file!(require_file)

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -87,13 +87,21 @@ module I18nJS
         load_require_file!(require_file) if require_file
 
         available_locales = I18n.available_locales
-        ignored_keys = config.dig(:lint_scripts, :ignore) || []
+        ignore_matchers =
+          (config.dig(:lint_scripts, :ignore) || []).map do |path|
+            Glob::Matcher.new(path)
+          end
 
         ui.stdout_print "=> Available locales: #{available_locales.inspect}"
 
         exported_files = I18nJS.call(config_file:)
-        data = exported_files.each_with_object({}) do |file, buffer|
-          buffer.merge!(JSON.load_file(file, symbolize_names: true))
+        translations = exported_files.each_with_object({}) do |file, buffer|
+          buffer.merge!(
+            I18nJS.deep_merge(
+              buffer,
+              JSON.load_file(file, symbolize_names: true)
+            )
+          )
         end
 
         lint_file = File.expand_path(File.join(__dir__, "../lint.js"))
@@ -108,20 +116,18 @@ module I18nJS
 
         out = IO.popen([node_path, lint_file, patterns.join(":")]).read
         scopes = JSON.parse(out, symbolize_names: true)
-        map = Glob::Map.call(data)
+        map = Glob::Map.call(translations)
+
         missing_count = 0
         ignored_count = 0
-
         messages = []
 
         available_locales.each do |locale|
           scopes.each do |scope|
-            scope_with_locale = "#{locale}.#{scope[:full]}"
+            full_scope = scope[:full]
+            scope_with_locale = "#{locale}.#{full_scope}"
 
-            ignored = ignored_keys.include?(scope[:full]) ||
-                      ignored_keys.include?(scope_with_locale)
-
-            if ignored
+            if ignored?(ignore_matchers, scope_with_locale)
               ignored_count += 1
               next
             end
@@ -138,6 +144,10 @@ module I18nJS
         ui.stdout_print messages.sort.join("\n")
 
         exit(missing_count)
+      end
+
+      private def ignored?(matchers, key)
+        matchers.any? {|matcher| matcher.match?(key) }
       end
 
       private def set_defaults!

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -118,8 +118,8 @@ module I18nJS
         scopes = JSON.parse(out, symbolize_names: true)
         map = Glob::Map.call(translations)
 
-        missing_count = 0
-        ignored_count = 0
+        ignored_keys = Set.new
+        missing_keys = Set.new
         messages = []
 
         available_locales.each do |locale|
@@ -128,16 +128,19 @@ module I18nJS
             scope_with_locale = "#{locale}.#{full_scope}"
 
             if ignored?(ignore_matchers, scope_with_locale)
-              ignored_count += 1
+              ignored_keys << scope_with_locale
               next
             end
 
             next if map.include?(scope_with_locale)
 
-            missing_count += 1
+            missing_keys << scope_with_locale
             messages << "   - #{scope[:location]}: #{scope_with_locale}"
           end
         end
+
+        ignored_count = ignored_keys.size
+        missing_count = missing_keys.size
 
         ui.stdout_print "=> #{map.size} translations, #{missing_count} " \
                         "missing, #{ignored_count} ignored"

--- a/lib/i18n-js/cli/lint_scripts_command.rb
+++ b/lib/i18n-js/cli/lint_scripts_command.rb
@@ -92,7 +92,17 @@ module I18nJS
             Glob::Matcher.new(path)
           end
 
-        ui.stdout_print "=> Available locales: #{available_locales.inspect}"
+        if ignore_matchers.any?
+          ui.stdout_print(
+            "=> Check",
+            options[:config_file].inspect,
+            "for ignored keys"
+          )
+        end
+
+        ui.stdout_print(
+          "=> Available locales: #{I18n.available_locales.inspect}"
+        )
 
         exported_files = I18nJS.call(config_file:)
         translations = exported_files.each_with_object({}) do |file, buffer|

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -82,37 +82,53 @@ module I18nJS
             Glob::Matcher.new(path)
           end
 
+        if ignore_matchers.any?
+          ui.stdout_print(
+            "=> Check",
+            options[:config_file].inspect,
+            "for ignored keys"
+          )
+        end
+
+        ui.stdout_print(
+          "=> Available locales: #{I18n.available_locales.inspect}"
+        )
+
         default_keys = build_locale_keys(default_locale)
 
         ui.stdout_print "=> #{default_locale}: #{default_keys.size} " \
                         "translations"
 
-        missing_count = 0
+        missing_keys = Set.new
 
         available_locales.each do |locale|
-          source_keys = default_keys
-                        .reject do |key|
-            ignored?(
-              ignore_matchers, "#{locale}.#{key}"
-            )
-          end
-          ignored_count = default_keys.size - source_keys.size
+          ignored = Set.new
+          missing = Set.new
+          extraneous = Set.new
 
+          ignored.merge(
+            default_keys
+            .select {|key| ignored?(ignore_matchers, "#{locale}.#{key}") }
+          )
+
+          source_keys = default_keys - ignored.to_a
           locale_keys = build_locale_keys(locale)
-          ignored = locale_keys.select do |key|
-            ignored?(ignore_matchers, "#{locale}.#{key}")
-          end
 
-          ignored_count += ignored.size
-          source_keys -= ignored
-          missing = source_keys - locale_keys
-          extraneous = locale_keys - source_keys - ignored
+          ignored.merge(
+            locale_keys
+            .select {|key| ignored?(ignore_matchers, "#{locale}.#{key}") }
+          )
 
-          missing_count += missing.size
+          ignored.merge(ignored)
+
+          source_keys -= ignored.to_a
+          missing.merge(source_keys - locale_keys)
+          extraneous.merge(locale_keys - source_keys - ignored.to_a)
+          missing_keys.merge(build_list_with_locale(missing, locale))
 
           ui.stdout_print "=> #{locale}: #{missing.size} missing, " \
                           "#{extraneous.size} extraneous, " \
-                          "#{ignored_count} ignored"
+                          "#{ignored.size} ignored"
 
           all_keys =
             (
@@ -131,11 +147,15 @@ module I18nJS
           end
         end
 
-        exit(missing_count)
+        exit(missing_keys.size)
       end
 
       def build_list_with_label(list, label)
         list.map {|item| [item, label] }
+      end
+
+      def build_list_with_locale(list, locale)
+        list.map {|item| "#{locale}.#{item}" }
       end
 
       def ignored?(matchers, key)

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -119,8 +119,6 @@ module I18nJS
             .select {|key| ignored?(ignore_matchers, "#{locale}.#{key}") }
           )
 
-          ignored.merge(ignored)
-
           source_keys -= ignored.to_a
           missing.merge(source_keys - locale_keys)
           extraneous.merge(locale_keys - source_keys - ignored.to_a)

--- a/lib/i18n-js/cli/lint_translations_command.rb
+++ b/lib/i18n-js/cli/lint_translations_command.rb
@@ -76,73 +76,80 @@ module I18nJS
 
         default_locale = I18n.default_locale
         available_locales = I18n.available_locales
-        ignored_keys = config.dig(:lint_translations, :ignore) || []
+                                .reject {|locale| locale == default_locale }
+        ignore_matchers =
+          (config.dig(:lint_translations, :ignore) || []).map do |path|
+            Glob::Matcher.new(path)
+          end
 
-        mapping = available_locales.each_with_object({}) do |locale, buffer|
-          buffer[locale] =
-            Glob::Map.call(Glob.filter(I18nJS.translations, ["#{locale}.*"]))
-                     .map {|key| key.gsub(/^.*?\./, "") }
-        end
+        default_keys = build_locale_keys(default_locale)
 
-        default_locale_keys = mapping.delete(default_locale) || mapping
-
-        if ignored_keys.any?
-          ui.stdout_print "=> Check #{options[:config_file].inspect} for " \
-                          "ignored keys."
-        end
-
-        ui.stdout_print "=> #{default_locale}: #{default_locale_keys.size} " \
+        ui.stdout_print "=> #{default_locale}: #{default_keys.size} " \
                         "translations"
 
-        total_missing_count = 0
+        missing_count = 0
 
-        mapping.each do |locale, partial_keys|
-          ignored_count = 0
+        available_locales.each do |locale|
+          source_keys = default_keys
+                        .reject do |key|
+            ignored?(
+              ignore_matchers, "#{locale}.#{key}"
+            )
+          end
+          ignored_count = default_keys.size - source_keys.size
 
-          # Compute list of filtered keys (i.e. keys not ignored)
-          filtered_keys = partial_keys.reject do |key|
-            key = "#{locale}.#{key}"
-
-            ignored = ignored_keys.include?(key)
-            ignored_count += 1 if ignored
-            ignored
+          locale_keys = build_locale_keys(locale)
+          ignored = locale_keys.select do |key|
+            ignored?(ignore_matchers, "#{locale}.#{key}")
           end
 
-          extraneous = (partial_keys - default_locale_keys).reject do |key|
-            key = "#{locale}.#{key}"
-            ignored = ignored_keys.include?(key)
-            ignored_count += 1 if ignored
-            ignored
-          end
+          ignored_count += ignored.size
+          source_keys -= ignored
+          missing = source_keys - locale_keys
+          extraneous = locale_keys - source_keys - ignored
 
-          missing = (default_locale_keys - (filtered_keys - extraneous))
-                    .reject {|key| ignored_keys.include?("#{locale}.#{key}") }
-
-          ignored_count += extraneous.size
-          total_missing_count += missing.size
+          missing_count += missing.size
 
           ui.stdout_print "=> #{locale}: #{missing.size} missing, " \
                           "#{extraneous.size} extraneous, " \
                           "#{ignored_count} ignored"
 
-          all_keys = (default_locale_keys + extraneous + missing).uniq.sort
+          all_keys =
+            (
+              build_list_with_label(missing, :missing) +
+              build_list_with_label(extraneous, :extraneous)
+            ).sort_by(&:first)
 
-          all_keys.each do |key|
-            next if ignored_keys.include?("#{locale}.#{key}")
-
-            label = if extraneous.include?(key)
+          all_keys.each do |key, label|
+            label = if label == :extraneous
                       ui.yellow("extraneous")
-                    elsif missing.include?(key)
-                      ui.red("missing")
                     else
-                      next
+                      ui.red("missing")
                     end
 
             ui.stdout_print("   - #{locale}.#{key} (#{label})")
           end
         end
 
-        exit(1) if total_missing_count.nonzero?
+        exit(missing_count)
+      end
+
+      def build_list_with_label(list, label)
+        list.map {|item| [item, label] }
+      end
+
+      def ignored?(matchers, key)
+        matchers.any? {|matcher| matcher.match?(key) }
+      end
+
+      private def build_locale_keys(locale)
+        Glob::Map
+          .call(Glob.filter(I18nJS.translations, ["#{locale}.*"]))
+          .map {|key| strip_locale(key) }
+      end
+
+      private def strip_locale(key)
+        key.gsub(/^.*?\./, "")
       end
 
       private def set_defaults!

--- a/lib/i18n-js/deep_merge.rb
+++ b/lib/i18n-js/deep_merge.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module I18nJS
+  # Based on deep_merge by Stefan Rusterholz, see
+  # <https://www.ruby-forum.com/topic/142809>.
+  # This method is used to handle I18n fallbacks. Given two equivalent path
+  # nodes in two locale trees:
+  # 1. If the node in the current locale appears to be an I18n pluralization
+  #    (:one, :other, etc.), use the node, but merge in any missing/non-nil
+  #    keys from the fallback (default) locale.
+  # 2. Else if both nodes are Hashes, combine (merge) the key-value pairs of
+  #    the two nodes into one, prioritizing the current locale.
+  # 3. Else if either node is nil, use the other node.
+
+  PLURAL_KEYS = %i[zero one two few many other].freeze
+  PLURAL_MERGER = proc {|_key, v1, v2| v1 || v2 }
+  MERGER = proc do |_key, v1, v2|
+    if v1.is_a?(Hash) && v2.is_a?(Hash)
+      if (v2.keys - PLURAL_KEYS).empty?
+        v2.merge(v1, &PLURAL_MERGER).slice(*v2.keys)
+      else
+        v1.merge(v2, &MERGER)
+      end
+    else
+      v2 || v1
+    end
+  end
+
+  def self.deep_merge(target_hash, hash)
+    target_hash.merge(hash, &MERGER)
+  end
+end

--- a/lib/i18n-js/embed_fallback_translations_plugin.rb
+++ b/lib/i18n-js/embed_fallback_translations_plugin.rb
@@ -4,37 +4,6 @@ module I18nJS
   require "i18n-js/plugin"
 
   class EmbedFallbackTranslationsPlugin < I18nJS::Plugin
-    module Utils
-      # Based on deep_merge by Stefan Rusterholz, see
-      # <https://www.ruby-forum.com/topic/142809>.
-      # This method is used to handle I18n fallbacks. Given two equivalent path
-      # nodes in two locale trees:
-      # 1. If the node in the current locale appears to be an I18n pluralization
-      #    (:one, :other, etc.), use the node, but merge in any missing/non-nil
-      #    keys from the fallback (default) locale.
-      # 2. Else if both nodes are Hashes, combine (merge) the key-value pairs of
-      #    the two nodes into one, prioritizing the current locale.
-      # 3. Else if either node is nil, use the other node.
-
-      PLURAL_KEYS = %i[zero one two few many other].freeze
-      PLURAL_MERGER = proc {|_key, v1, v2| v1 || v2 }
-      MERGER = proc do |_key, v1, v2|
-        if v1.is_a?(Hash) && v2.is_a?(Hash)
-          if (v2.keys - PLURAL_KEYS).empty?
-            v2.merge(v1, &PLURAL_MERGER).slice(*v2.keys)
-          else
-            v1.merge(v2, &MERGER)
-          end
-        else
-          v2 || v1
-        end
-      end
-
-      def self.deep_merge(target_hash, hash)
-        target_hash.merge(hash, &MERGER)
-      end
-    end
-
     def validate_schema
       valid_keys = %i[enabled]
 
@@ -53,7 +22,7 @@ module I18nJS
         translations[fallback_locale]
 
       locales_to_fallback.each do |locale|
-        translations_with_fallback[locale] = Utils.deep_merge(
+        translations_with_fallback[locale] = I18nJS.deep_merge(
           translations[fallback_locale], translations[locale]
         )
       end

--- a/test/config/group.yml
+++ b/test/config/group.yml
@@ -2,4 +2,4 @@
 translations:
   - file: test/output/group.json
     patterns:
-      - "{pt,en}.time for bed!"
+      - "{pt,en}.time_for_bed"

--- a/test/config/lint_scripts.yml
+++ b/test/config/lint_scripts.yml
@@ -11,5 +11,5 @@ lint_scripts:
     - "!(node_modules)/**/*.jsx"
     - "!(node_modules)/**/*.tsx"
   ignore:
-    - ignore_scope
+    - "*.ignore_scope"
     - pt.another_ignore_scope

--- a/test/config/lint_translations.yml
+++ b/test/config/lint_translations.yml
@@ -6,7 +6,5 @@ translations:
 
 lint_translations:
   ignore:
-    - "es.bye"
-    - "es.hello sunshine!"
-    - "pt.bye"
-    - "pt.hello sunshine!"
+    - "*.bye"
+    - "*.hello_sunshine"

--- a/test/config/specific.yml
+++ b/test/config/specific.yml
@@ -3,4 +3,4 @@ translations:
   - file: test/output/specific.json
     patterns:
       - "*.bye"
-      - "*.time for bed!"
+      - "*.time_for_bed"

--- a/test/fixtures/expected/embed_fallback_translations.json
+++ b/test/fixtures/expected/embed_fallback_translations.json
@@ -1,23 +1,23 @@
 {
   "en": {
-    "bunny rabbit adventure": "bunny rabbit adventure",
+    "bunny_rabbit_adventure": "bunny rabbit adventure",
     "counting": {
       "one": "This is one!"
     },
-    "hello sunshine!": "hello sunshine!",
-    "time for bed!": "time for bed!",
+    "hello_sunshine": "hello sunshine!",
+    "time_for_bed": "time for bed!",
     "words": {
       "bye": "Goodbye!",
       "hello": "Hi!"
     }
   },
   "es": {
-    "bunny rabbit adventure": "conejito conejo aventura",
+    "bunny_rabbit_adventure": "conejito conejo aventura",
     "counting": {
       "one": "This is one!"
     },
-    "hello sunshine!": "hello sunshine!",
-    "time for bed!": "hora de acostarse!",
+    "hello_sunshine": "hello sunshine!",
+    "time_for_bed": "hora de acostarse!",
     "words": {
       "bye": "Goodbye!",
       "hello": "Hi!"
@@ -25,12 +25,12 @@
     "bye": "adios"
   },
   "pt": {
-    "bunny rabbit adventure": "a aventura da coelhinha",
+    "bunny_rabbit_adventure": "a aventura da coelhinha",
     "counting": {
       "one": "Esse é um!"
     },
-    "hello sunshine!": "hello sunshine!",
-    "time for bed!": "hora de dormir!",
+    "hello_sunshine": "hello sunshine!",
+    "time_for_bed": "hora de dormir!",
     "words": {
       "bye": "Adeus!",
       "hello": "Hi!"

--- a/test/fixtures/expected/everything.json
+++ b/test/fixtures/expected/everything.json
@@ -1,17 +1,17 @@
 {
   "en": {
-    "bunny rabbit adventure": "bunny rabbit adventure",
-    "time for bed!": "time for bed!",
-    "hello sunshine!": "hello sunshine!"
+    "bunny_rabbit_adventure": "bunny rabbit adventure",
+    "time_for_bed": "time for bed!",
+    "hello_sunshine": "hello sunshine!"
   },
   "es": {
-    "bunny rabbit adventure": "conejito conejo aventura",
+    "bunny_rabbit_adventure": "conejito conejo aventura",
     "bye": "adios",
-    "time for bed!": "hora de acostarse!"
+    "time_for_bed": "hora de acostarse!"
   },
   "pt": {
-    "bunny rabbit adventure": "a aventura da coelhinha",
+    "bunny_rabbit_adventure": "a aventura da coelhinha",
     "bye": "tchau",
-    "time for bed!": "hora de dormir!"
+    "time_for_bed": "hora de dormir!"
   }
 }

--- a/test/fixtures/expected/export_files.ts
+++ b/test/fixtures/expected/export_files.ts
@@ -4,18 +4,18 @@ import { i18n } from "config/i18n";
 
 i18n.store({
   "en": {
-    "bunny rabbit adventure": "bunny rabbit adventure",
-    "hello sunshine!": "hello sunshine!",
-    "time for bed!": "time for bed!"
+    "bunny_rabbit_adventure": "bunny rabbit adventure",
+    "hello_sunshine": "hello sunshine!",
+    "time_for_bed": "time for bed!"
   },
   "es": {
-    "bunny rabbit adventure": "conejito conejo aventura",
+    "bunny_rabbit_adventure": "conejito conejo aventura",
     "bye": "adios",
-    "time for bed!": "hora de acostarse!"
+    "time_for_bed": "hora de acostarse!"
   },
   "pt": {
-    "bunny rabbit adventure": "a aventura da coelhinha",
+    "bunny_rabbit_adventure": "a aventura da coelhinha",
     "bye": "tchau",
-    "time for bed!": "hora de dormir!"
+    "time_for_bed": "hora de dormir!"
   }
 });

--- a/test/fixtures/expected/group.json
+++ b/test/fixtures/expected/group.json
@@ -1,8 +1,8 @@
 {
   "en": {
-    "time for bed!": "time for bed!"
+    "time_for_bed": "time for bed!"
   },
   "pt": {
-    "time for bed!": "hora de dormir!"
+    "time_for_bed": "hora de dormir!"
   }
 }

--- a/test/fixtures/expected/lint.txt
+++ b/test/fixtures/expected/lint.txt
@@ -3,7 +3,7 @@
 => Node: "%{node}"
 => Available locales: [:en, :es, :pt]
 => Patterns: ["!(node_modules)/**/*.js", "!(node_modules)/**/*.ts", "!(node_modules)/**/*.jsx", "!(node_modules)/**/*.tsx"]
-=> 9 translations, 11 missing, 4 ignored
+=> 9 translations, 8 missing, 4 ignored
    - test/scripts/lint/file.js:1:1: en.js.missing
    - test/scripts/lint/file.js:1:1: es.js.missing
    - test/scripts/lint/file.js:1:1: pt.js.missing

--- a/test/fixtures/expected/lint.txt
+++ b/test/fixtures/expected/lint.txt
@@ -1,6 +1,7 @@
 => Config file: "test/config/lint_scripts.yml"
 => Require file: "test/config/require.rb"
 => Node: "%{node}"
+=> Check "test/config/lint_scripts.yml" for ignored keys
 => Available locales: [:en, :es, :pt]
 => Patterns: ["!(node_modules)/**/*.js", "!(node_modules)/**/*.ts", "!(node_modules)/**/*.jsx", "!(node_modules)/**/*.tsx"]
 => 9 translations, 8 missing, 4 ignored

--- a/test/fixtures/expected/multiple_files/en.json
+++ b/test/fixtures/expected/multiple_files/en.json
@@ -1,7 +1,7 @@
 {
   "en": {
-    "bunny rabbit adventure": "bunny rabbit adventure",
-    "hello sunshine!": "hello sunshine!",
-    "time for bed!": "time for bed!"
+    "bunny_rabbit_adventure": "bunny rabbit adventure",
+    "hello_sunshine": "hello sunshine!",
+    "time_for_bed": "time for bed!"
   }
 }

--- a/test/fixtures/expected/multiple_files/es.json
+++ b/test/fixtures/expected/multiple_files/es.json
@@ -1,7 +1,7 @@
 {
   "es": {
-    "bunny rabbit adventure": "conejito conejo aventura",
+    "bunny_rabbit_adventure": "conejito conejo aventura",
     "bye": "adios",
-    "time for bed!": "hora de acostarse!"
+    "time_for_bed": "hora de acostarse!"
   }
 }

--- a/test/fixtures/expected/multiple_files/pt.json
+++ b/test/fixtures/expected/multiple_files/pt.json
@@ -1,7 +1,7 @@
 {
   "pt": {
-    "bunny rabbit adventure": "a aventura da coelhinha",
+    "bunny_rabbit_adventure": "a aventura da coelhinha",
     "bye": "tchau",
-    "time for bed!": "hora de dormir!"
+    "time_for_bed": "hora de dormir!"
   }
 }

--- a/test/fixtures/expected/specific.json
+++ b/test/fixtures/expected/specific.json
@@ -1,13 +1,13 @@
 {
   "en": {
-    "time for bed!": "time for bed!"
+    "time_for_bed": "time for bed!"
   },
   "es": {
     "bye": "adios",
-    "time for bed!": "hora de acostarse!"
+    "time_for_bed": "hora de acostarse!"
   },
   "pt": {
     "bye": "tchau",
-    "time for bed!": "hora de dormir!"
+    "time_for_bed": "hora de dormir!"
   }
 }

--- a/test/fixtures/expected/transformed.json
+++ b/test/fixtures/expected/transformed.json
@@ -1,20 +1,20 @@
 {
   "en": {
-    "bunny rabbit adventure": "bunny rabbit adventure",
-    "time for bed!": "time for bed!",
-    "hello sunshine!": "hello sunshine!",
+    "bunny_rabbit_adventure": "bunny rabbit adventure",
+    "time_for_bed": "time for bed!",
+    "hello_sunshine": "hello sunshine!",
     "injected": "yes:en"
   },
   "es": {
-    "bunny rabbit adventure": "conejito conejo aventura",
+    "bunny_rabbit_adventure": "conejito conejo aventura",
     "bye": "adios",
-    "time for bed!": "hora de acostarse!",
+    "time_for_bed": "hora de acostarse!",
     "injected": "yes:es"
   },
   "pt": {
-    "bunny rabbit adventure": "a aventura da coelhinha",
+    "bunny_rabbit_adventure": "a aventura da coelhinha",
     "bye": "tchau",
-    "time for bed!": "hora de dormir!",
+    "time_for_bed": "hora de dormir!",
     "injected": "yes:pt"
   }
 }

--- a/test/fixtures/po/en.po
+++ b/test/fixtures/po/en.po
@@ -1,8 +1,8 @@
-msgid "hello sunshine!"
+msgid "hello_sunshine"
 msgstr "hello sunshine!"
 
-msgid "bunny rabbit adventure"
+msgid "bunny_rabbit_adventure"
 msgstr "bunny rabbit adventure"
 
-msgid "time for bed!"
+msgid "time_for_bed"
 msgstr "time for bed!"

--- a/test/fixtures/po/es.po
+++ b/test/fixtures/po/es.po
@@ -1,8 +1,8 @@
 msgid "bye"
 msgstr "adios"
 
-msgid "bunny rabbit adventure"
+msgid "bunny_rabbit_adventure"
 msgstr "conejito conejo aventura"
 
-msgid "time for bed!"
+msgid "time_for_bed"
 msgstr "hora de acostarse!"

--- a/test/fixtures/po/pt.po
+++ b/test/fixtures/po/pt.po
@@ -1,8 +1,8 @@
 msgid "bye"
 msgstr "tchau"
 
-msgid "bunny rabbit adventure"
+msgid "bunny_rabbit_adventure"
 msgstr "a aventura da coelhinha"
 
-msgid "time for bed!"
+msgid "time_for_bed"
 msgstr "hora de dormir!"

--- a/test/fixtures/yml/en.yml
+++ b/test/fixtures/yml/en.yml
@@ -1,5 +1,5 @@
 ---
 en:
-  hello sunshine!: hello sunshine!
-  bunny rabbit adventure: bunny rabbit adventure
-  time for bed!: time for bed!
+  hello_sunshine: hello sunshine!
+  bunny_rabbit_adventure: bunny rabbit adventure
+  time_for_bed: time for bed!

--- a/test/fixtures/yml/es.yml
+++ b/test/fixtures/yml/es.yml
@@ -1,5 +1,5 @@
 ---
 es:
   bye: "adios"
-  bunny rabbit adventure: conejito conejo aventura
-  time for bed!: hora de acostarse!
+  bunny_rabbit_adventure: conejito conejo aventura
+  time_for_bed: hora de acostarse!

--- a/test/fixtures/yml/pt.yml
+++ b/test/fixtures/yml/pt.yml
@@ -1,5 +1,5 @@
 ---
 pt:
   bye: "tchau"
-  bunny rabbit adventure: a aventura da coelhinha
-  time for bed!: hora de dormir!
+  bunny_rabbit_adventure: a aventura da coelhinha
+  time_for_bed: hora de dormir!

--- a/test/i18n-js/cli/lint_scripts_command_test.rb
+++ b/test/i18n-js/cli/lint_scripts_command_test.rb
@@ -108,7 +108,7 @@ class LintCommandTest < Minitest::Test
       stderr:
     )
 
-    assert_exit_code(11) { cli.call }
+    assert_exit_code(8) { cli.call }
 
     output = format(
       File.read("./test/fixtures/expected/lint.txt"),

--- a/test/i18n-js/cli/lint_translations_command_test.rb
+++ b/test/i18n-js/cli/lint_translations_command_test.rb
@@ -104,7 +104,7 @@ class LintTranslationsCommandTest < Minitest::Test
       stderr:
     )
 
-    assert_exit_code(1) { cli.call }
+    assert_exit_code(2) { cli.call }
 
     output = stdout.tap(&:rewind).read.chomp
 
@@ -123,17 +123,17 @@ class LintTranslationsCommandTest < Minitest::Test
       stderr:
     )
 
-    assert_exit_code(1) { cli.call }
+    assert_exit_code(2) { cli.call }
 
     output = stdout.tap(&:rewind).read.chomp
 
     assert_includes output, "=> en: 3 translations"
     assert_includes output, "=> es: 1 missing, 1 extraneous"
     assert_includes output, "- es.bye (extraneous)"
-    assert_includes output, "- es.hello sunshine! (missing)"
+    assert_includes output, "- es.hello_sunshine (missing)"
     assert_includes output, "=> pt: 1 missing, 1 extraneous"
     assert_includes output, "- pt.bye (extraneous)"
-    assert_includes output, "- pt.hello sunshine! (missing)"
+    assert_includes output, "- pt.hello_sunshine (missing)"
   end
 
   test "ignores translations" do

--- a/test/i18n-js/export_files_plugin_test.rb
+++ b/test/i18n-js/export_files_plugin_test.rb
@@ -12,7 +12,7 @@ class ExportScriptFilesPluginTest < Minitest::Test
     Time.stubs(:now).returns(now)
 
     exported_file =
-      "test/output/export_files-3d4fd73158044f2545580d5fd9d09c77.ts"
+      "test/output/export_files-a21c90181a5fddc55bf998edc5f4a5ca.ts"
 
     actual_files =
       I18nJS.call(config_file: "./test/config/export_files.yml")

--- a/test/i18n-js/exporter_test.rb
+++ b/test/i18n-js/exporter_test.rb
@@ -129,20 +129,20 @@ class ExporterTest < Minitest::Test
     actual_files = I18nJS.call(config_file: "./test/config/digest.yml")
 
     expected_files = [
-      "test/output/en.913d6b883381e2f2eefaa24054591aa6.json",
-      "test/output/es.0158e18c349c0f67702b24f750431143.json",
-      "test/output/pt.5b66b78c6d06dc6e0783f47f2d46940f.json"
+      "test/output/en.950ef8b554852123e348521115051af4.json",
+      "test/output/es.755043ec22e785c6b92edd5ae4b1b70c.json",
+      "test/output/pt.e57f5dde9957ac6fb34651f9a1714b47.json"
     ]
 
     assert_exported_files expected_files, actual_files
     assert_json_file "test/fixtures/expected/multiple_files/en.json",
-                     "test/output/en.913d6b883381e2f2eefaa24054591aa6.json"
+                     "test/output/en.950ef8b554852123e348521115051af4.json"
 
     assert_json_file "test/fixtures/expected/multiple_files/es.json",
-                     "test/output/es.0158e18c349c0f67702b24f750431143.json"
+                     "test/output/es.755043ec22e785c6b92edd5ae4b1b70c.json"
 
     assert_json_file "test/fixtures/expected/multiple_files/pt.json",
-                     "test/output/pt.5b66b78c6d06dc6e0783f47f2d46940f.json"
+                     "test/output/pt.e57f5dde9957ac6fb34651f9a1714b47.json"
   end
 
   test "exports files using groups" do

--- a/test/scripts/lint/file.js
+++ b/test/scripts/lint/file.js
@@ -1,6 +1,6 @@
 i18n.t("js.missing");
 i18n.t("js.missing", { scope: "base" });
-i18n.t("bunny rabbit adventure");
-i18n.t("js.missing", { defaults: [{ scope: "bunny rabbit adventure" }] });
+i18n.t("bunny_rabbit_adventure");
+i18n.t("js.missing", { defaults: [{ scope: "bunny_rabbit_adventure" }] });
 i18n.t("ignore_scope");
 i18n.t("another_ignore_scope");


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [ ] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Allow lint's ignore to have globs.

### Why

- Close #707
- Close #724 (this pr uses `glob`, rather than `File.fnmatch`)

### Known limitations

N/A
